### PR TITLE
Limit input in AddWordDialog to 128 characters (fix #96)

### DIFF
--- a/src/components/vocabulary/AddWordDialog.jsx
+++ b/src/components/vocabulary/AddWordDialog.jsx
@@ -5,6 +5,8 @@ import {useState} from "react";
 import {addWord} from "../../services/vocabularyService.js";
 import {toaster} from "../ui/toaster.jsx";
 
+const WORD_MAX_LENGTH = 128;
+
 function AddWordDialogContent({setIsOpen, onAdd}) {
     const dialog = useDialogContext();
 
@@ -57,6 +59,7 @@ function AddWordDialogContent({setIsOpen, onAdd}) {
                     placeholder="Enter new word"
                     value={word}
                     onChange={e => setWord(e.target.value)}
+                    maxLength={WORD_MAX_LENGTH}
                 />
             </Dialog.Body>
             <Dialog.Footer>


### PR DESCRIPTION
This PR addresses issue #96 by limiting the input in the AddWordDialog component to 128 characters using the maxLength property.

- Introduced a WORD_MAX_LENGTH constant and applied it to the input field.
- No other changes were made.

This prevents users from entering excessively long words that could negatively impact both UI and API.