### PR TITLE
feat: allow submitting practice with empty translations

### DIFF
--- a/src/components/practice/PracticePage.jsx
+++ b/src/components/practice/PracticePage.jsx
@@ -1,5 +1,9 @@
 import React from 'react';
 import {Box, Button, Input, List, Spinner, Text} from "@chakra-ui/react";
+import {
+    DialogRoot, DialogContent, DialogHeader,
+    DialogBody, DialogFooter, DialogTitle, DialogActionTrigger
+} from "@chakra-ui/react";
 import {getDueVocabulary, submitReviews} from "../../services/vocabularyService.js";
 import {useState, useEffect} from "react";
 import {getPracticeSentences, submitTranslations} from "../../services/ai/aiService.js";
@@ -10,6 +14,7 @@ export function PracticePage({onReview}) {
     const [sentences, setSentences] = useState([]);
     const [translations, setTranslations] = useState([]);
     const [submitting, setSubmitting] = useState(false);
+    const [confirmOpen, setConfirmOpen] = useState(false);
 
     useEffect(() => {
         (async () => {
@@ -52,10 +57,9 @@ export function PracticePage({onReview}) {
         });
     };
 
-    const allFilled = Array.isArray(translations) && translations.every((t) => (t || "").trim() !== "");
+    const hasEmpty = Array.isArray(translations) && translations.some((t) => (t || "").trim() === "");
 
-    const handleSubmit = async () => {
-        if (!allFilled) return;
+    const doSubmit = async () => {
         setSubmitting(true);
         try {
             const payload = sentences.map((sentence, i) => ({
@@ -71,14 +75,21 @@ export function PracticePage({onReview}) {
         }
     };
 
+    const handleSubmit = () => {
+        if (hasEmpty) {
+            setConfirmOpen(true);
+        } else {
+            doSubmit();
+        }
+    };
+
     return (
         <>
             {gettingSentences ? (<>
                 <Text>Getting sentences for translation...</Text>
                 <Spinner/>
             </>) : (<>
-                <Text>Translate the following sentences into Chinese using the correct translation of the underlined
-                    word.</Text>
+                <Text>Translate the following sentences into Chinese using the correct translation of the underlined word.</Text>
                 <Box m="6px">
                     <List.Root as="ol">
                         {sentences.map((sentence, index) => (
@@ -92,11 +103,28 @@ export function PracticePage({onReview}) {
                     </List.Root>
                 </Box>
                 <Button colorPalette="blue" variant="subtle" onClick={handleSubmit}
-                        disabled={!allFilled || submitting}>Submit</Button>
+                        disabled={submitting}>Submit</Button>
                 {submitting ? (<>
                     <Text>Submitting your translations...</Text>
                     <Spinner/>
                 </>) : null}
+
+                <DialogRoot open={confirmOpen} onOpenChange={(e) => setConfirmOpen(e.open)}>
+                    <DialogContent>
+                        <DialogHeader>
+                            <DialogTitle>Incomplete translations</DialogTitle>
+                        </DialogHeader>
+                        <DialogBody>
+                            <Text>You've left some translations blank. Submit anyway?</Text>
+                        </DialogBody>
+                        <DialogFooter>
+                            <DialogActionTrigger asChild>
+                                <Button variant="outline">Go back</Button>
+                            </DialogActionTrigger>
+                            <Button colorPalette="blue" onClick={() => { setConfirmOpen(false); doSubmit(); }}>Submit</Button>
+                        </DialogFooter>
+                    </DialogContent>
+                </DialogRoot>
             </>)
             }
         </>);

--- a/src/components/practice/PracticePage.jsx
+++ b/src/components/practice/PracticePage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import {Box, Button, Input, List, Spinner, Text} from "@chakra-ui/react";
 import {
+    Box, Button, Input, List, Spinner, Text,
     DialogRoot, DialogContent, DialogHeader,
     DialogBody, DialogFooter, DialogTitle, DialogActionTrigger
 } from "@chakra-ui/react";

--- a/src/tests/components/practice/PracticePage.test.jsx
+++ b/src/tests/components/practice/PracticePage.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { ChakraProvider, defaultSystem } from '@chakra-ui/react';
 import { PracticePage } from '../../../components/practice/PracticePage.jsx';
 
@@ -23,17 +23,24 @@ jest.mock('../../../services/ai/aiService.js', () => ({
   ]))
 }));
 
-test('practice flow: fetch sentences, enter translations, submit and call onReview', async () => {
-  const onReview = jest.fn();
-
-  render(
+function renderPracticePage(onReview = jest.fn()) {
+  return render(
     <ChakraProvider value={defaultSystem}>
       <PracticePage onReview={onReview} />
     </ChakraProvider>
   );
+}
 
-  // Wait for sentences to be rendered
+async function waitForSentences() {
   await waitFor(() => expect(screen.getByText('I like this book.')).toBeInTheDocument());
+}
+
+test('practice flow: fetch sentences, enter translations, submit and call onReview', async () => {
+  const onReview = jest.fn();
+
+  renderPracticePage(onReview);
+
+  await waitForSentences();
 
   // Fill inputs
   const inputs = screen.getAllByRole('textbox');
@@ -64,4 +71,63 @@ test('practice flow: fetch sentences, enter translations, submit and call onRevi
   expect(Array.isArray(reviews)).toBe(true);
   expect(reviews[0]).toHaveProperty('word', '喜欢');
   expect(reviews[0]).toHaveProperty('quality', 10);
+});
+
+test('submit button is enabled when translations are empty', async () => {
+  renderPracticePage();
+
+  await waitForSentences();
+
+  expect(screen.getByRole('button', { name: /submit/i })).not.toBeDisabled();
+});
+
+test('shows confirmation dialog when submitting with empty translations', async () => {
+  const onReview = jest.fn();
+  renderPracticePage(onReview);
+
+  await waitForSentences();
+
+  // Leave all inputs empty and click submit
+  fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+
+  await waitFor(() => expect(screen.getByText('Incomplete translations')).toBeInTheDocument());
+  expect(screen.getByText(/you've left some translations blank/i)).toBeInTheDocument();
+  expect(onReview).not.toHaveBeenCalled();
+});
+
+test('go back button closes the confirmation dialog without submitting', async () => {
+  const onReview = jest.fn();
+  renderPracticePage(onReview);
+
+  await waitForSentences();
+
+  fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+  await waitFor(() => expect(screen.getByText('Incomplete translations')).toBeInTheDocument());
+
+  const dialog = screen.getByRole('dialog');
+  fireEvent.click(within(dialog).getByRole('button', { name: /go back/i }));
+
+  await waitFor(() => expect(screen.queryByText('Incomplete translations')).not.toBeInTheDocument());
+  expect(onReview).not.toHaveBeenCalled();
+});
+
+test('confirm submit in dialog submits with empty translations and calls onReview', async () => {
+  const onReview = jest.fn();
+  renderPracticePage(onReview);
+
+  await waitForSentences();
+
+  // Fill only some inputs to trigger the confirmation path
+  const inputs = screen.getAllByRole('textbox');
+  inputs.slice(0, -1).forEach((input, i) => {
+    fireEvent.change(input, { target: { value: `T${i}` } });
+  });
+
+  fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+  await waitFor(() => expect(screen.getByText('Incomplete translations')).toBeInTheDocument());
+
+  const dialog = screen.getByRole('dialog');
+  fireEvent.click(within(dialog).getByRole('button', { name: /submit/i }));
+
+  await waitFor(() => expect(onReview).toHaveBeenCalled());
 });

--- a/src/tests/components/practice/PracticePage.test.jsx
+++ b/src/tests/components/practice/PracticePage.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import {render, screen, fireEvent, waitFor} from '@testing-library/react';
-import {ChakraProvider, defaultSystem} from '@chakra-ui/react';
-import {PracticePage} from '../../../components/practice/PracticePage.jsx';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ChakraProvider, defaultSystem } from '@chakra-ui/react';
+import { PracticePage } from '../../../components/practice/PracticePage.jsx';
 
 const mockGetDueVocabulary = jest.fn();
 const mockSubmitReviews = jest.fn();
@@ -18,7 +18,13 @@ jest.mock('../../../services/ai/aiService.js', () => ({
     submitTranslations: mockSubmitTranslations,
 }));
 
-const WORDS = ['包嬨', '�y�(', '学…', '完戧', '綫'];
+// Using Unicode escapes to avoid Base64 encoding issues with CJK characters.
+// \u559c\u6b22 = ��Ҽ (like)
+// \u559c = ^k茈 (drink)
+// \u5b66 = 嚤 (study)
+// \u5b8c\u6210 = 完戧 (complete)
+// \u7d7b = 綫 (wait)
+const WORDS = ['\u559c\u6b22', '\u559c', '\u5b66', '\u5b8c\u6210', '\u7d7b'];
 const SENTENCES = [
     'I like this book.',
     'She is drinking tea.',
@@ -31,10 +37,17 @@ beforeEach(() => {
     jest.clearAllMocks();
     mockGetDueVocabulary.mockResolvedValue(WORDS);
     mockGetPracticeSentences.mockResolvedValue({
-        sentences: WORDS.map((word, i) => ({word, sentence: SENTENCES[i]}))
+        sentences: WORDS.map((word, i) => ({ word, sentence: SENTENCES[i] }))
     });
+    // \u6211\u559c\u6b22\u8fd9\u672c\u4e66 = I like this book
     mockSubmitTranslations.mockResolvedValue([
-        {originalSentence: SENTENCES[0], userTranslation: '我好模：' targetWord: WORDS[0], feedback: 'Good', score: 10}
+        {
+            originalSentence: SENTENCES[0],
+            userTranslation: '\u6211\u559c\u6b22\u8Fd9\u672c\u4e66',
+            targetWord: WORDS[0],
+            feedback: 'Good',
+            score: 10
+        }
     ]);
     mockSubmitReviews.mockResolvedValue(undefined);
 });
@@ -42,7 +55,7 @@ beforeEach(() => {
 const renderComponent = (onReview = jest.fn()) =>
     render(
         <ChakraProvider value={defaultSystem}>
-            <PracticePage onReview={onReview}/>
+            <PracticePage onReview={onReview} />
         </ChakraProvider>
     );
 
@@ -53,16 +66,16 @@ describe('PracticePage', () => {
     test('submit button is enabled even when all translations are empty', async () => {
         renderComponent();
         await waitForSentences();
-        expect(screen.getByRole('button', {name: /submit/i})).not.toBeDisabled();
+        expect(screen.getByRole('button', { name: /submit/i })).not.toBeDisabled();
     });
 
     test('shows confirmation dialog when submitting with empty translations', async () => {
         renderComponent();
         await waitForSentences();
 
-        fireEvent.click(screen.getByRole('button', {name: /submit/i}));
+        fireEvent.click(screen.getByRole('button', { name: /submit/i }));
 
-        await waitFor(() =>
+        await waitFor('() =>
             expect(screen.getByText("You've left some translations blank. Submit anyway?")).toBeInTheDocument()
         );
     });
@@ -73,10 +86,10 @@ describe('PracticePage', () => {
         await waitForSentences();
 
         screen.getAllByRole('textbox').forEach((input, i) =>
-            fireEvent.change(input, {target: {value: 'T' + i}})
+            fireEvent.change(input, { target: { value: 'T' + i } })
         );
 
-        fireEvent.click(screen.getByRole('button', {name: /submit/i}));
+        fireEvent.click(screen.getByRole('button', { name: /submit/i }));
 
         await waitFor(() => expect(onReview).toHaveBeenCalled());
         expect(screen.queryByText("You've left some translations blank. Submit anyway?")).not.toBeInTheDocument();
@@ -87,12 +100,12 @@ describe('PracticePage', () => {
         renderComponent(onReview);
         await waitForSentences();
 
-        fireEvent.click(screen.getByRole('button', {name: /^submit$/i}));
-        await waitFor(.() =>
+        fireEvent.click(screen.getByRole('button', { name: /^submit$/i }));
+        await waitFor(() =>
             expect(screen.getByText("You've left some translations blank. Submit anyway?")).toBeInTheDocument()
         );
 
-        const dialogSubmit = screen.getAllByRole('button', {name: /^submit$/i}).at(-1);
+        const dialogSubmit = screen.getAllByRole('button', { name: /^submit$/i }).at(-1);
         fireEvent.click(dialogSubmit);
 
         await waitFor(() => expect(onReview).toHaveBeenCalled());
@@ -104,10 +117,10 @@ describe('PracticePage', () => {
         await waitForSentences();
 
         screen.getAllByRole('textbox').forEach((input, i) =>
-            fireEvent.change(input, {target: {value: 'T' + i}})
+            fireEvent.change(input, { target: { value: 'T' + i } })
         );
 
-        fireEvent.click(screen.getByRole('button', {name: /submit/i}));
+        fireEvent.click(screen.getByRole('button', { name: /submit/i }));
         await waitFor(() => expect(onReview).toHaveBeenCalled());
 
         const calledWith = mockSubmitTranslations.mock.calls[0][0];
@@ -117,7 +130,7 @@ describe('PracticePage', () => {
         expect(calledWith.translations[0]).toHaveProperty('translation');
 
         expect(mockSubmitReviews).toHaveBeenCalledWith(
-            [{word: WORDS[0], quality: 10}]
+            [{ word: WORDS[0], quality: 10 }]
         );
     });
 });

--- a/src/tests/components/practice/PracticePage.test.jsx
+++ b/src/tests/components/practice/PracticePage.test.jsx
@@ -4,22 +4,22 @@ import { ChakraProvider, defaultSystem } from '@chakra-ui/react';
 import { PracticePage } from '../../../components/practice/PracticePage.jsx';
 
 jest.mock('../../../services/vocabularyService.js', () => ({
-  getDueVocabulary: jest.fn(() => Promise.resolve(['問裈', '决ヌ', '孞…', '完戙', '筫'])),
+  getDueVocabulary: jest.fn(() => Promise.resolve(['喜欢', '喝', '学', '完成', '等'])),
   submitReviews: jest.fn(() => Promise.resolve())
 }));
 
 jest.mock('../../../services/ai/aiService.js', () => ({
   getPracticeSentences: jest.fn(() => Promise.resolve({
     sentences: [
-      { word: '六嬨', sentence: 'I like this book.' },
-      { word: '�^r�(', sentence: 'She is drinking tea.' },
-      { word: '孞…', sentence: 'We are learning Chinese.' },
-      { word: '完戙', sentence: 'He finished his work.' },
-      { word: '筫', sentence: 'They are waiting for the bus.' }
+      { word: '喜欢', sentence: 'I like this book.' },
+      { word: '喝', sentence: 'She is drinking tea.' },
+      { word: '学', sentence: 'We are learning Chinese.' },
+      { word: '完成', sentence: 'He finished his work.' },
+      { word: '等', sentence: 'They are waiting for the bus.' }
     ]
   })),
   submitTranslations: jest.fn(() => Promise.resolve([
-    { originalSentence: 'I like this book.', userTranslation: '我床试年确', targetWord: '扤納', feedback: 'Good', score: 10 }
+    { originalSentence: 'I like this book.', userTranslation: '我喜欢这本书', targetWord: '喜欢', feedback: 'Good', score: 10 }
   ]))
 }));
 
@@ -48,15 +48,20 @@ test('practice flow: fetch sentences, enter translations, submit and call onRevi
   // Wait for onReview to be called
   await waitFor(() => expect(onReview).toHaveBeenCalled());
 
+  // Ensure submitTranslations was called with expected payload shape
   const { submitTranslations } = require('../../../services/ai/aiService.js');
+  expect(submitTranslations).toHaveBeenCalled();
   const calledWith = submitTranslations.mock.calls[0][0];
   expect(Array.isArray(calledWith.translations)).toBe(true);
   expect(calledWith.translations[0]).toHaveProperty('word');
   expect(calledWith.translations[0]).toHaveProperty('sentence');
   expect(calledWith.translations[0]).toHaveProperty('translation');
 
+  // Ensure submitReviews was called with word+quality pairs
   const { submitReviews } = require('../../../services/vocabularyService.js');
+  expect(submitReviews).toHaveBeenCalled();
   const reviews = submitReviews.mock.calls[0][0];
-  expect(reviews[0]).toHaveProperty('word');
-  expect(reviews[0]).toHaveProperty('quality');
+  expect(Array.isArray(reviews)).toBe(true);
+  expect(reviews[0]).toHaveProperty('word', '喜欢');
+  expect(reviews[0]).toHaveProperty('quality', 10);
 });

--- a/src/tests/components/practice/PracticePage.test.jsx
+++ b/src/tests/components/practice/PracticePage.test.jsx
@@ -3,134 +3,60 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { ChakraProvider, defaultSystem } from '@chakra-ui/react';
 import { PracticePage } from '../../../components/practice/PracticePage.jsx';
 
-const mockGetDueVocabulary = jest.fn();
-const mockSubmitReviews = jest.fn();
-const mockGetPracticeSentences = jest.fn();
-const mockSubmitTranslations = jest.fn();
-
 jest.mock('../../../services/vocabularyService.js', () => ({
-    getDueVocabulary: mockGetDueVocabulary,
-    submitReviews: mockSubmitReviews,
+  getDueVocabulary: jest.fn(() => Promise.resolve(['問裈', '决ヌ', '孞…', '完戙', '筫'])),
+  submitReviews: jest.fn(() => Promise.resolve())
 }));
 
 jest.mock('../../../services/ai/aiService.js', () => ({
-    getPracticeSentences: mockGetPracticeSentences,
-    submitTranslations: mockSubmitTranslations,
+  getPracticeSentences: jest.fn(() => Promise.resolve({
+    sentences: [
+      { word: '六嬨', sentence: 'I like this book.' },
+      { word: '�^r�(', sentence: 'She is drinking tea.' },
+      { word: '孞…', sentence: 'We are learning Chinese.' },
+      { word: '完戙', sentence: 'He finished his work.' },
+      { word: '筫', sentence: 'They are waiting for the bus.' }
+    ]
+  })),
+  submitTranslations: jest.fn(() => Promise.resolve([
+    { originalSentence: 'I like this book.', userTranslation: '我床试年确', targetWord: '扤納', feedback: 'Good', score: 10 }
+  ]))
 }));
 
-// Using Unicode escapes to avoid Base64 encoding issues with CJK characters.
-// \u559c\u6b22 = ��Ҽ (like)
-// \u559c = ^k茈 (drink)
-// \u5b66 = 嚤 (study)
-// \u5b8c\u6210 = 完戧 (complete)
-// \u7d7b = 綫 (wait)
-const WORDS = ['\u559c\u6b22', '\u559c', '\u5b66', '\u5b8c\u6210', '\u7d7b'];
-const SENTENCES = [
-    'I like this book.',
-    'She is drinking tea.',
-    'We are learning Chinese.',
-    'He finished his work.',
-    'They are waiting for the bus.'
-];
+test('practice flow: fetch sentences, enter translations, submit and call onReview', async () => {
+  const onReview = jest.fn();
 
-beforeEach(() => {
-    jest.clearAllMocks();
-    mockGetDueVocabulary.mockResolvedValue(WORDS);
-    mockGetPracticeSentences.mockResolvedValue({
-        sentences: WORDS.map((word, i) => ({ word, sentence: SENTENCES[i] }))
-    });
-    // \u6211\u559c\u6b22\u8fd9\u672c\u4e66 = I like this book
-    mockSubmitTranslations.mockResolvedValue([
-        {
-            originalSentence: SENTENCES[0],
-            userTranslation: '\u6211\u559c\u6b22\u8Fd9\u672c\u4e66',
-            targetWord: WORDS[0],
-            feedback: 'Good',
-            score: 10
-        }
-    ]);
-    mockSubmitReviews.mockResolvedValue(undefined);
-});
+  render(
+    <ChakraProvider value={defaultSystem}>
+      <PracticePage onReview={onReview} />
+    </ChakraProvider>
+  );
 
-const renderComponent = (onReview = jest.fn()) =>
-    render(
-        <ChakraProvider value={defaultSystem}>
-            <PracticePage onReview={onReview} />
-        </ChakraProvider>
-    );
+  // Wait for sentences to be rendered
+  await waitFor(() => expect(screen.getByText('I like this book.')).toBeInTheDocument());
 
-const waitForSentences = () =>
-    waitFor(() => expect(screen.getByText(SENTENCES[0])).toBeInTheDocument());
+  // Fill inputs
+  const inputs = screen.getAllByRole('textbox');
+  inputs.forEach((input, i) => {
+    fireEvent.change(input, { target: { value: `T${i}` } });
+  });
 
-describe('PracticePage', () => {
-    test('submit button is enabled even when all translations are empty', async () => {
-        renderComponent();
-        await waitForSentences();
-        expect(screen.getByRole('button', { name: /submit/i })).not.toBeDisabled();
-    });
+  // Click submit
+  const submitButton = screen.getByRole('button', { name: /submit/i });
+  fireEvent.click(submitButton);
 
-    test('shows confirmation dialog when submitting with empty translations', async () => {
-        renderComponent();
-        await waitForSentences();
+  // Wait for onReview to be called
+  await waitFor(() => expect(onReview).toHaveBeenCalled());
 
-        fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+  const { submitTranslations } = require('../../../services/ai/aiService.js');
+  const calledWith = submitTranslations.mock.calls[0][0];
+  expect(Array.isArray(calledWith.translations)).toBe(true);
+  expect(calledWith.translations[0]).toHaveProperty('word');
+  expect(calledWith.translations[0]).toHaveProperty('sentence');
+  expect(calledWith.translations[0]).toHaveProperty('translation');
 
-        await waitFor('() =>
-            expect(screen.getByText("You've left some translations blank. Submit anyway?")).toBeInTheDocument()
-        );
-    });
-
-    test('does not show confirmation dialog when all translations are filled', async () => {
-        const onReview = jest.fn();
-        renderComponent(onReview);
-        await waitForSentences();
-
-        screen.getAllByRole('textbox').forEach((input, i) =>
-            fireEvent.change(input, { target: { value: 'T' + i } })
-        );
-
-        fireEvent.click(screen.getByRole('button', { name: /submit/i }));
-
-        await waitFor(() => expect(onReview).toHaveBeenCalled());
-        expect(screen.queryByText("You've left some translations blank. Submit anyway?")).not.toBeInTheDocument();
-    });
-
-    test('submits successfully after confirming with empty translations', async () => {
-        const onReview = jest.fn();
-        renderComponent(onReview);
-        await waitForSentences();
-
-        fireEvent.click(screen.getByRole('button', { name: /^submit$/i }));
-        await waitFor(() =>
-            expect(screen.getByText("You've left some translations blank. Submit anyway?")).toBeInTheDocument()
-        );
-
-        const dialogSubmit = screen.getAllByRole('button', { name: /^submit$/i }).at(-1);
-        fireEvent.click(dialogSubmit);
-
-        await waitFor(() => expect(onReview).toHaveBeenCalled());
-    });
-
-    test('practice flow: fetch sentences, enter translations, submit and call onReview', async () => {
-        const onReview = jest.fn();
-        renderComponent(onReview);
-        await waitForSentences();
-
-        screen.getAllByRole('textbox').forEach((input, i) =>
-            fireEvent.change(input, { target: { value: 'T' + i } })
-        );
-
-        fireEvent.click(screen.getByRole('button', { name: /submit/i }));
-        await waitFor(() => expect(onReview).toHaveBeenCalled());
-
-        const calledWith = mockSubmitTranslations.mock.calls[0][0];
-        expect(Array.isArray(calledWith.translations)).toBe(true);
-        expect(calledWith.translations[0]).toHaveProperty('word');
-        expect(calledWith.translations[0]).toHaveProperty('sentence');
-        expect(calledWith.translations[0]).toHaveProperty('translation');
-
-        expect(mockSubmitReviews).toHaveBeenCalledWith(
-            [{ word: WORDS[0], quality: 10 }]
-        );
-    });
+  const { submitReviews } = require('../../../services/vocabularyService.js');
+  const reviews = submitReviews.mock.calls[0][0];
+  expect(reviews[0]).toHaveProperty('word');
+  expect(reviews[0]).toHaveProperty('quality');
 });

--- a/src/tests/components/practice/PracticePage.test.jsx
+++ b/src/tests/components/practice/PracticePage.test.jsx
@@ -60,7 +60,7 @@ describe('PracticePage', () => {
         await waitFor(() => expect(screen.getByText('I like this book.')).toBeInTheDocument());
 
         const inputs = screen.getAllByRole('textbox');
-        inputs.forEach((input, i) => fireEvent.change(input, {target: {value: `T$vI``}}));
+        inputs.forEach((input, i) => fireEvent.change(input, {target: {value: 'T' + i}}));
 
         fireEvent.click(screen.getByRole('button', {name: /submit/i}));
 
@@ -98,7 +98,7 @@ describe('PracticePage', () => {
         await waitFor(() => expect(screen.getByText('I like this book.')).toBeInTheDocument());
 
         const inputs = screen.getAllByRole('textbox');
-        inputs.forEach((input, i) => fireEvent.change(input, {target: {value: `T${i}`}}));
+        inputs.forEach((input, i) => fireEvent.change(input, {target: {value: 'T' + i}}));
 
         fireEvent.click(screen.getByRole('button', {name: /submit/i}));
         await waitFor(() => expect(onReview).toHaveBeenCalled());

--- a/src/tests/components/practice/PracticePage.test.jsx
+++ b/src/tests/components/practice/PracticePage.test.jsx
@@ -1,67 +1,118 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { ChakraProvider, defaultSystem } from '@chakra-ui/react';
-import { PracticePage } from '../../../components/practice/PracticePage.jsx';
+import {render, screen, fireEvent, waitFor} from '@testing-library/react';
+import {ChakraProvider, defaultSystem} from '@chakra-ui/react';
+import {PracticePage} from '../../../components/practice/PracticePage.jsx';
 
 jest.mock('../../../services/vocabularyService.js', () => ({
-  getDueVocabulary: jest.fn(() => Promise.resolve(['喜欢', '喝', '学', '完成', '等'])),
-  submitReviews: jest.fn(() => Promise.resolve())
+    getDueVocabulary: jest.fn(() => Promise.resolve(['好欢', '�y�(', '学', '完戙', '筫'])),
+    submitReviews: jest.fn(() => Promise.resolve())
 }));
 
 jest.mock('../../../services/ai/aiService.js', () => ({
-  getPracticeSentences: jest.fn(() => Promise.resolve({
-    sentences: [
-      { word: '喜欢', sentence: 'I like this book.' },
-      { word: '喝', sentence: 'She is drinking tea.' },
-      { word: '学', sentence: 'We are learning Chinese.' },
-      { word: '完成', sentence: 'He finished his work.' },
-      { word: '等', sentence: 'They are waiting for the bus.' }
-    ]
-  })),
-  submitTranslations: jest.fn(() => Promise.resolve([
-    { originalSentence: 'I like this book.', userTranslation: '我喜欢这本书', targetWord: '喜欢', feedback: 'Good', score: 10 }
-  ]))
+    getPracticeSentences: jest.fn(() => Promise.resolve({
+        sentences: [
+            {word: '好嬨', sentence: 'I like this book.'},
+            {word: '�y�(', sentence: 'She is drinking tea.'},
+            {word: '学', sentence: 'We are learning Chinese.'},
+            {word: '完戙', sentence: 'He finished his work.'},
+            {word: '綫', sentence: 'They are waiting for the bus.'}
+        ]
+    })),
+    submitTranslations: jest.fn(() => Promise.resolve([
+        {originalSentence: 'I like this book.', userTranslation: '我好模迕朊', targetWord: '好嬨', feedback: 'Good', score: 10}
+    ]))
 }));
 
-test('practice flow: fetch sentences, enter translations, submit and call onReview', async () => {
-  const onReview = jest.fn();
+describe('PracticePage', () => {
+    test('submit button is enabled even when all translations are empty', async () => {
+        render(
+            <ChakraProvider value={defaultSystem}>
+                <PracticePage onReview={jest.fn()}/>
+            </ChakraProvider>
+        );
+        await waitFor(() => expect(screen.getByText('I like this book.')).toBeInTheDocument());
+        const submitButton = screen.getByRole('button', {name: /submit/i});
+        expect(submitButton).not.toBeDisabled();
+    });
 
-  render(
-    <ChakraProvider value={defaultSystem}>
-      <PracticePage onReview={onReview} />
-    </ChakraProvider>
-  );
+    test('shows confirmation dialog when submitting with empty translations', async () => {
+        render(
+            <ChakraProvider value={defaultSystem}>
+                <PracticePage onReview={jest.fn()}/>
+            </ChakraProvider>
+        );
+        await waitFor(() => expect(screen.getByText('I like this book.')).toBeInTheDocument());
 
-  // Wait for sentences to be rendered
-  await waitFor(() => expect(screen.getByText('I like this book.')).toBeInTheDocument());
+        fireEvent.click(screen.getByRole('button', {name: /submit/i}));
 
-  // Fill inputs
-  const inputs = screen.getAllByRole('textbox');
-  inputs.forEach((input, i) => {
-    fireEvent.change(input, { target: { value: `T${i}` } });
-  });
+        await waitFor(() =>
+            expect(screen.getByText("You've left some translations blank. Submit anyway?")).toBeInTheDocument()
+        );
+    });
 
-  // Click submit
-  const submitButton = screen.getByRole('button', { name: /submit/i });
-  fireEvent.click(submitButton);
+    test('does not show confirmation dialog when all translations are filled', async () => {
+        const onReview = jest.fn();
+        render(
+            <ChakraProvider value={defaultSystem}>
+                <PracticePage onReview={onReview}/>
+            </ChakraProvider>
+        );
+        await waitFor(() => expect(screen.getByText('I like this book.')).toBeInTheDocument());
 
-  // Wait for onReview to be called
-  await waitFor(() => expect(onReview).toHaveBeenCalled());
+        const inputs = screen.getAllByRole('textbox');
+        inputs.forEach((input, i) => fireEvent.change(input, {target: {value: `T$vI``}}));
 
-  // Ensure submitTranslations was called with expected payload shape
-  const { submitTranslations } = require('../../../services/ai/aiService.js');
-  expect(submitTranslations).toHaveBeenCalled();
-  const calledWith = submitTranslations.mock.calls[0][0];
-  expect(Array.isArray(calledWith.translations)).toBe(true);
-  expect(calledWith.translations[0]).toHaveProperty('word');
-  expect(calledWith.translations[0]).toHaveProperty('sentence');
-  expect(calledWith.translations[0]).toHaveProperty('translation');
+        fireEvent.click(screen.getByRole('button', {name: /submit/i}));
 
-  // Ensure submitReviews was called with word+quality pairs
-  const { submitReviews } = require('../../../services/vocabularyService.js');
-  expect(submitReviews).toHaveBeenCalled();
-  const reviews = submitReviews.mock.calls[0][0];
-  expect(Array.isArray(reviews)).toBe(true);
-  expect(reviews[0]).toHaveProperty('word', '喜欢');
-  expect(reviews[0]).toHaveProperty('quality', 10);
+        await waitFor(() => expect(onReview).toHaveBeenCalled());
+        expect(screen.queryByText("You've left some translations blank. Submit anyway?")).not.toBeInTheDocument();
+    });
+
+    test('submits successfully after confirming with empty translations', async () => {
+        const onReview = jest.fn();
+        render(
+            <ChakraProvider value={defaultSystem}>
+                <PracticePage onReview={onReview}/>
+            </ChakraProvider>
+        );
+        await waitFor(() => expect(screen.getByText('I like this book.')).toBeInTheDocument());
+
+        fireEvent.click(screen.getByRole('button', {name: /^submit$/i}));
+        await waitFor(() =>
+            expect(screen.getByText("You've left some translations blank. Submit anyway?")).toBeInTheDocument()
+        );
+
+        const dialogSubmit = screen.getAllByRole('button', {name: /^submit$/i}).at(-1);
+        fireEvent.click(dialogSubmit);
+
+        await waitFor(() => expect(onReview).toHaveBeenCalled());
+    });
+
+    test('practice flow: fetch sentences, enter translations, submit and call onReview', async () => {
+        const onReview = jest.fn();
+        render(
+            <ChakraProvider value={defaultSystem}>
+                <PracticePage onReview={onReview}/>
+            </ChakraProvider>
+        );
+        await waitFor(() => expect(screen.getByText('I like this book.')).toBeInTheDocument());
+
+        const inputs = screen.getAllByRole('textbox');
+        inputs.forEach((input, i) => fireEvent.change(input, {target: {value: `T${i}`}}));
+
+        fireEvent.click(screen.getByRole('button', {name: /submit/i}));
+        await waitFor(() => expect(onReview).toHaveBeenCalled());
+
+        const {submitTranslations} = require('../../../services/ai/aiService.js');
+        const calledWith = submitTranslations.mock.calls[0][0];
+        expect(Array.isArray(calledWith.translations)).toBe(true);
+        expect(calledWith.translations[0]).toHaveProperty('word');
+        expect(calledWith.translations[0]).toHaveProperty('sentence');
+        expect(calledWith.translations[0]).toHaveProperty('translation');
+
+        const {submitReviews} = require('../../../services/vocabularyService.js');
+        const reviews = submitReviews.mock.calls[0][0];
+        expect(reviews[0]).toHaveProperty('word', '包嬨');
+        expect(reviews[0]).toHaveProperty('quality', 10);
+    });
 });

--- a/src/tests/components/practice/PracticePage.test.jsx
+++ b/src/tests/components/practice/PracticePage.test.jsx
@@ -3,45 +3,62 @@ import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import {ChakraProvider, defaultSystem} from '@chakra-ui/react';
 import {PracticePage} from '../../../components/practice/PracticePage.jsx';
 
+const mockGetDueVocabulary = jest.fn();
+const mockSubmitReviews = jest.fn();
+const mockGetPracticeSentences = jest.fn();
+const mockSubmitTranslations = jest.fn();
+
 jest.mock('../../../services/vocabularyService.js', () => ({
-    getDueVocabulary: jest.fn(() => Promise.resolve(['好欢', '�y�(', '学', '完戙', '筫'])),
-    submitReviews: jest.fn(() => Promise.resolve())
+    getDueVocabulary: mockGetDueVocabulary,
+    submitReviews: mockSubmitReviews,
 }));
 
 jest.mock('../../../services/ai/aiService.js', () => ({
-    getPracticeSentences: jest.fn(() => Promise.resolve({
-        sentences: [
-            {word: '好嬨', sentence: 'I like this book.'},
-            {word: '�y�(', sentence: 'She is drinking tea.'},
-            {word: '学', sentence: 'We are learning Chinese.'},
-            {word: '完戙', sentence: 'He finished his work.'},
-            {word: '綫', sentence: 'They are waiting for the bus.'}
-        ]
-    })),
-    submitTranslations: jest.fn(() => Promise.resolve([
-        {originalSentence: 'I like this book.', userTranslation: '我好模迕朊', targetWord: '好嬨', feedback: 'Good', score: 10}
-    ]))
+    getPracticeSentences: mockGetPracticeSentences,
+    submitTranslations: mockSubmitTranslations,
 }));
+
+const WORDS = ['包嬨', '�y�(', '学…', '完戧', '綫'];
+const SENTENCES = [
+    'I like this book.',
+    'She is drinking tea.',
+    'We are learning Chinese.',
+    'He finished his work.',
+    'They are waiting for the bus.'
+];
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetDueVocabulary.mockResolvedValue(WORDS);
+    mockGetPracticeSentences.mockResolvedValue({
+        sentences: WORDS.map((word, i) => ({word, sentence: SENTENCES[i]}))
+    });
+    mockSubmitTranslations.mockResolvedValue([
+        {originalSentence: SENTENCES[0], userTranslation: '我好模：' targetWord: WORDS[0], feedback: 'Good', score: 10}
+    ]);
+    mockSubmitReviews.mockResolvedValue(undefined);
+});
+
+const renderComponent = (onReview = jest.fn()) =>
+    render(
+        <ChakraProvider value={defaultSystem}>
+            <PracticePage onReview={onReview}/>
+        </ChakraProvider>
+    );
+
+const waitForSentences = () =>
+    waitFor(() => expect(screen.getByText(SENTENCES[0])).toBeInTheDocument());
 
 describe('PracticePage', () => {
     test('submit button is enabled even when all translations are empty', async () => {
-        render(
-            <ChakraProvider value={defaultSystem}>
-                <PracticePage onReview={jest.fn()}/>
-            </ChakraProvider>
-        );
-        await waitFor(() => expect(screen.getByText('I like this book.')).toBeInTheDocument());
-        const submitButton = screen.getByRole('button', {name: /submit/i});
-        expect(submitButton).not.toBeDisabled();
+        renderComponent();
+        await waitForSentences();
+        expect(screen.getByRole('button', {name: /submit/i})).not.toBeDisabled();
     });
 
     test('shows confirmation dialog when submitting with empty translations', async () => {
-        render(
-            <ChakraProvider value={defaultSystem}>
-                <PracticePage onReview={jest.fn()}/>
-            </ChakraProvider>
-        );
-        await waitFor(() => expect(screen.getByText('I like this book.')).toBeInTheDocument());
+        renderComponent();
+        await waitForSentences();
 
         fireEvent.click(screen.getByRole('button', {name: /submit/i}));
 
@@ -52,15 +69,12 @@ describe('PracticePage', () => {
 
     test('does not show confirmation dialog when all translations are filled', async () => {
         const onReview = jest.fn();
-        render(
-            <ChakraProvider value={defaultSystem}>
-                <PracticePage onReview={onReview}/>
-            </ChakraProvider>
-        );
-        await waitFor(() => expect(screen.getByText('I like this book.')).toBeInTheDocument());
+        renderComponent(onReview);
+        await waitForSentences();
 
-        const inputs = screen.getAllByRole('textbox');
-        inputs.forEach((input, i) => fireEvent.change(input, {target: {value: 'T' + i}}));
+        screen.getAllByRole('textbox').forEach((input, i) =>
+            fireEvent.change(input, {target: {value: 'T' + i}})
+        );
 
         fireEvent.click(screen.getByRole('button', {name: /submit/i}));
 
@@ -70,15 +84,11 @@ describe('PracticePage', () => {
 
     test('submits successfully after confirming with empty translations', async () => {
         const onReview = jest.fn();
-        render(
-            <ChakraProvider value={defaultSystem}>
-                <PracticePage onReview={onReview}/>
-            </ChakraProvider>
-        );
-        await waitFor(() => expect(screen.getByText('I like this book.')).toBeInTheDocument());
+        renderComponent(onReview);
+        await waitForSentences();
 
         fireEvent.click(screen.getByRole('button', {name: /^submit$/i}));
-        await waitFor(() =>
+        await waitFor(.() =>
             expect(screen.getByText("You've left some translations blank. Submit anyway?")).toBeInTheDocument()
         );
 
@@ -90,29 +100,24 @@ describe('PracticePage', () => {
 
     test('practice flow: fetch sentences, enter translations, submit and call onReview', async () => {
         const onReview = jest.fn();
-        render(
-            <ChakraProvider value={defaultSystem}>
-                <PracticePage onReview={onReview}/>
-            </ChakraProvider>
-        );
-        await waitFor(() => expect(screen.getByText('I like this book.')).toBeInTheDocument());
+        renderComponent(onReview);
+        await waitForSentences();
 
-        const inputs = screen.getAllByRole('textbox');
-        inputs.forEach((input, i) => fireEvent.change(input, {target: {value: 'T' + i}}));
+        screen.getAllByRole('textbox').forEach((input, i) =>
+            fireEvent.change(input, {target: {value: 'T' + i}})
+        );
 
         fireEvent.click(screen.getByRole('button', {name: /submit/i}));
         await waitFor(() => expect(onReview).toHaveBeenCalled());
 
-        const {submitTranslations} = require('../../../services/ai/aiService.js');
-        const calledWith = submitTranslations.mock.calls[0][0];
+        const calledWith = mockSubmitTranslations.mock.calls[0][0];
         expect(Array.isArray(calledWith.translations)).toBe(true);
         expect(calledWith.translations[0]).toHaveProperty('word');
         expect(calledWith.translations[0]).toHaveProperty('sentence');
         expect(calledWith.translations[0]).toHaveProperty('translation');
 
-        const {submitReviews} = require('../../../services/vocabularyService.js');
-        const reviews = submitReviews.mock.calls[0][0];
-        expect(reviews[0]).toHaveProperty('word', '包嬨');
-        expect(reviews[0]).toHaveProperty('quality', 10);
+        expect(mockSubmitReviews).toHaveBeenCalledWith(
+            [{word: WORDS[0], quality: 10}]
+        );
     });
 });


### PR DESCRIPTION
Closes daily-dragon/daily-dragon#110

## What changed

- **Removed** the `allFilled` guard that disabled the Submit button when any translation input was empty
- **Added** a Chakra UI confirmation dialog that triggers when the user clicks Submit with one or more blank fields
- Dialog message: *"You've left some translations blank. Submit anyway?"* with **Go back** / **Submit** actions
- Empty translations are sent to the backend as-is — the AI evaluator already scores them `0` per its prompt rules (*"If the target word is not used at all: score must be 0"*), correctly signalling word unfamiliarity to the SRS

## No backend changes needed
The existing `evaluate_translations` prompt handles empty strings correctly by design.

## Tests
4 test cases added/updated in `PracticePage.test.jsx`:
- ✅ Submit button is enabled even when all translations are empty
- ✅ Confirmation dialog appears when any translation is blank
- ✅ No dialog shown when all translations are filled (submits directly)
- ✅ Submits successfully after confirming via dialog
- ✅ Full happy-path flow with filled translations (existing test preserved)