### PR TITLE
feat: minimal simplistic page design (#115)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,20 @@
+/* ¯Global reset & base */
+*, *::before, *::after {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+html, body {
+    height: 100%;
+    background-color: #f8fafc;
+}
+
+#root {
+    min-height: 100%;
+}
+
+/* Layout helpers */
 .centered {
     display: flex;
     flex-direction: column;
@@ -5,6 +22,23 @@
     width: 100%;
 }
 
+.page-wrapper {
+    width: 100%;
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 0 1rem;
+}
+
+/* Aws Amplify auth ui overrides -- centre the auth card nicely */
+[data-amplify-authenticator] {
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: #f8fafc;
+}
+
+/* Utility */
 ul.no-bullets {
     list-style-type: none;
     padding-left: 0;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import './App.css';
-import {Box} from "@chakra-ui/react";
+import {Box, Container} from "@chakra-ui/react";
 import '@aws-amplify/ui-react/styles.css';
 import {Route, Routes} from 'react-router-dom';
 import Home from './components/Home.jsx';
@@ -27,21 +27,21 @@ function App() {
                 console.error('Failed to fetch auth session:', error);
             }
         }
-
         getToken();
     }, []);
 
     return (
         <Authenticator signUpAttributes={["email"]}>
             {({signOut, user}) => (
-                <Box className="centered" p={4}>
+                <Box className="centered" minH="100vh" bg="gray.50">
                     <Header user={user} signOut={signOut}/>
-
-                    <Routes>
-                        <Route path="/" element={<Home/>}/>
-                        <Route path="/vocabulary" element={<VocabularyPage/>}/>
-                        <Route path="/practice" element={<Practice/>}/>
-                    </Routes>
+                    <Container maxW="800px" width="100%" px={4} py={6}>
+                        <Routes>
+                            <Route path="/" element={<Home/>}/>
+                            <Route path="/vocabulary" element={<VocabularyPage/>}/>
+                            <Route path="/practice" element={<Practice/>}/>
+                        </Routes>
+                    </Container>
                 </Box>
             )}
         </Authenticator>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,24 +1,58 @@
-import {Heading, Text, HStack, Box, IconButton, Flex} from "@chakra-ui/react";
+import {Heading, Text, HStack, Box, IconButton, Flex, Separator} from "@chakra-ui/react";
 import {FiLogOut} from "react-icons/fi";
 import {Link} from "react-router-dom";
 
 export default function Header({user, signOut}) {
     return (
-        <Flex width="100%" align="center" py={3}>
-            <Box flex={1}/>
-            <Link to="/" style={{textDecoration: "none"}}>
-                <Heading size="2xl" colorPalette="blue">每日龙</Heading>
-            </Link>
-            <Box flex={1}>
-                <HStack justify="flex-end">
-                    <Text fontSize="sm">
-                        Welcome <Box as="span" fontWeight="bold">{user.username}</Box>
-                    </Text>
-                    <IconButton size="sm" onClick={signOut} colorPalette="blue" variant="outline">
-                        <FiLogOut/>
-                    </IconButton>
-                </HStack>
-            </Box>
-        </Flex>
+        <Box
+            as="header"
+            width="100%"
+            bg="white"
+            boxShadow="sm"
+            position="sticky"
+            top={0}
+            zIndex={10}
+        >
+            <Flex
+                maxW="800px"
+                mx="auto"
+                px={4}
+                py={3}
+                align="center"
+            >
+                <Box flex={1}/>
+                <Link to="/" style={{textDecoration: "none"}}>
+                    <HStack gap={2} align="center">
+                        <Text fontSize="2xl">🐩</Text>
+                        <Heading
+                            size="xl"
+                            color="blue.600"
+                            letterSpacing="wider"
+                            fontWeight="bold"
+                        >
+                            毫�_配
+                        </Heading>
+                    </HStack>
+                </Link>
+                <Box flex={1}>
+                    <HStack justify="flex-end" gap={2} align="center">
+                        <Text fontSize="sm" color="gray.600" display={{base: "none", sm: "block"}}>
+                            {user.username}
+                        </Text>
+                        <IconButton
+                            aria-label="Sign out"
+                            size="sm"
+                            onClick={signOut}
+                            colorPalette="blue"
+                            variant="outline"
+                            title="Sign out"
+                        >
+                            <FiLogOut/>
+                        </IconButton>
+                    </HStack>
+                </Box>
+            </Flex>
+            <Separator/>
+        </Box>
     );
 }

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -1,15 +1,69 @@
-import {Button, VStack} from "@chakra-ui/react";
+import {Button, VStack, Heading, Text, Box, HStack} from "@chakra-ui/react";
 import {useNavigate} from "react-router-dom";
+import {FiBook, FiZap} from "react-icons/fi";
 
 export default function Home() {
     const navigate = useNavigate();
 
     return (
-        <>
-            <VStack spacing={4} mt={4}>
-                <Button onClick={() => navigate("/vocabulary")}>Vocabulary</Button>
-                <Button onClick={() => navigate("/practice")}>Practice</Button>
+        <VStack gap={8} align="center" mt={8}>
+            <VStack gap={2} textAlign="center">
+                <Text fontSize="5xl">🐩</Text>
+                <Heading size="2xl" color="blue.600">Daily Dragon</Heading>
+                <Text color="gray.500" fontSize="md">
+                    Your daily Chinese practice companion
+                </Text>
             </VStack>
-        </>
+
+            <HStack gap={4} flexWrap="wrap" justify="center">
+                <Box
+                    as="button"
+                    onClick={() => navigate("/vocabulary")}
+                    cursor="pointer"
+                    bg="white"
+                    borderWidth="1px"
+                    borderColor="gray.200"
+                    borderRadius="xl"
+                    p={6}
+                    w={"160px"}
+                    _hover={{bg: "blue.50", borderColor: "blue.300", transform: "translateY(-2px)"}}
+                    transition="all 0.2s"
+                >
+                    <VStack gap={2} align="center">
+                        <Text fontSize="3xl"><FiBook/></Text>
+                        <Text fontWeight="semibold" fontSize="md">
+                            Vocabulary
+                        </Text>
+                        <Text fontSize="xs" color="gray.500" textAlign="center">
+                            Manage your word list
+                        </Text>
+                    </VStack>
+                </Box>
+
+                <Box
+                    as="button"
+                    onClick={() => navigate("/practice")}
+                    cursor="pointer"
+                    bg="white"
+                    borderWidth="1px"
+                    borderColor="gray.200"
+                    borderRadius="xl"
+                    p={6}
+                    w={"160px"}
+                    _hover={{bg: "blue.50", borderColor: "blue.300", transform: "translateY(-2px)"}}
+                    transition="all 0.2s"
+                >
+                    <VStack gap={2} align="center">
+                        <Text fontSize="3xl"><FiZap/></Text>
+                        <Text fontWeight="semibold" fontSize="md">
+                            Practice
+                        </Text>
+                        <Text fontSize="xs" color="gray.500" textAlign="center">
+                            Translate sentences
+                        </Text>
+                    </VStack>
+                </Box>
+            </HStack>
+        </VStack>
     )
 }

--- a/src/components/practice/PracticePage.jsx
+++ b/src/components/practice/PracticePage.jsx
@@ -1,18 +1,19 @@
 import React from 'react';
 import {
-    Box, Button, Input, List, Spinner, Text,
+    Box, Button, Input, List, Spinner, Text, VStack, HStack, Heading,
     DialogRoot, DialogContent, DialogHeader,
     DialogBody, DialogFooter, DialogTitle, DialogActionTrigger
 } from "@chakra-ui/react";
 import {getDueVocabulary, submitReviews} from "../../services/vocabularyService.js";
 import {useState, useEffect} from "react";
 import {getPracticeSentences, submitTranslations} from "../../services/ai/aiService.js";
+import {FiZap} from "react-icons/fi";
 
 export function PracticePage({onReview}) {
     const [gettingSentences, setGettingSentences] = useState(true);
     const [words, setWords] = useState([]);
     const [sentences, setSentences] = useState([]);
-    const [translations, setTranslations] = useState([]);
+    const [translations, sendTranslations] = useState([]);
     const [submitting, setSubmitting] = useState(false);
     const [confirmOpen, setConfirmOpen] = useState(false);
 
@@ -24,11 +25,8 @@ export function PracticePage({onReview}) {
             let sentencesResult = await getPracticeSentences(words);
 
             if (typeof sentencesResult === 'string') {
-                try {
-                    sentencesResult = JSON.parse(sentencesResult);
-                } catch (e) {
-                    console.error('Failed to parse sentences response:', e);
-                }
+                try { sentencesResult = JSON.parse(sentencesResult); }
+                catch (e) { console.error('Failed to parse sentences response:', e); }
             }
 
             let sentencesArray = [];
@@ -36,21 +34,18 @@ export function PracticePage({onReview}) {
                 sentencesArray = sentencesResult;
             } else if (sentencesResult && Array.isArray(sentencesResult.sentences)) {
                 sentencesArray = sentencesResult.sentences.map(s => s.sentence || s);
-
                 const returnedWords = sentencesResult.sentences.map(s => s.word).filter(Boolean);
-                if (returnedWords.length === sentencesArray.length) {
-                    setWords(returnedWords);
-                }
+                if (returnedWords.length === sentencesArray.length) setWords(returnedWords);
             }
 
             setSentences(sentencesArray);
-            setTranslations(Array(sentencesArray.length).fill(""));
+            sendTranslations(Array(sentencesArray.length).fill(""));
             setGettingSentences(false);
         })();
     }, []);
 
     const handleInputChange = (index, value) => {
-        setTranslations((prev) => {
+        sendTranslations((prev) => {
             const updated = [...prev];
             updated[index] = value;
             return updated;
@@ -63,9 +58,7 @@ export function PracticePage({onReview}) {
         setSubmitting(true);
         try {
             const payload = sentences.map((sentence, i) => ({
-                word: words[i],
-                sentence,
-                translation: translations[i]
+                word: words[i], sentence, translation: translations[i]
             }));
             const review = await submitTranslations({translations: payload});
             await submitReviews(review.map(r => ({word: r.targetWord, quality: r.score})));
@@ -76,56 +69,94 @@ export function PracticePage({onReview}) {
     };
 
     const handleSubmit = () => {
-        if (hasEmpty) {
-            setConfirmOpen(true);
-        } else {
-            doSubmit();
-        }
+        if (hasEmpty) setConfirmOpen(true);
+        else doSubmit();
     };
 
-    return (
-        <>
-            {gettingSentences ? (<>
-                <Text>Getting sentences for translation...</Text>
-                <Spinner/>
-            </>) : (<>
-                <Text>Translate the following sentences into Chinese using the correct translation of the underlined word.</Text>
-                <Box m="6px">
-                    <List.Root as="ol">
-                        {sentences.map((sentence, index) => (
-                            <List.Item key={index}>{sentence}
-                                <Input
-                                    value={translations[index]}
-                                    onChange={(e) => handleInputChange(index, e.target.value)}
-                                />
-                            </List.Item>
-                        ))}
-                    </List.Root>
-                </Box>
-                <Button colorPalette="blue" variant="subtle" onClick={handleSubmit}
-                        disabled={submitting}>Submit</Button>
-                {submitting ? (<>
-                    <Text>Submitting your translations...</Text>
-                    <Spinner/>
-                </>) : null}
+    if (gettingSentences) {
+        return (
+            <VStack
+                align="center"
+                py={16}
+                bg="white"
+                borderRadius="xl"
+                borderWidth="1px"
+                borderColor="gray.100"
+                gap={4}
+            >
+                <Spinner size="xl" color="blue.500"/>
+                <Text color="gray.500">Getting sentences for translation...</Text>
+            </VStack>
+        );
+    }
 
-                <DialogRoot open={confirmOpen} onOpenChange={(e) => setConfirmOpen(e.open)}>
-                    <DialogContent>
-                        <DialogHeader>
-                            <DialogTitle>Incomplete translations</DialogTitle>
-                        </DialogHeader>
-                        <DialogBody>
-                            <Text>You've left some translations blank. Submit anyway?</Text>
-                        </DialogBody>
-                        <DialogFooter>
-                            <DialogActionTrigger asChild>
-                                <Button variant="outline">Go back</Button>
-                            </DialogActionTrigger>
-                            <Button colorPalette="blue" onClick={() => { setConfirmOpen(false); doSubmit(); }}>Submit</Button>
-                        </DialogFooter>
-                    </DialogContent>
-                </DialogRoot>
-            </>)
-            }
-        </>);
+    return (
+        <VStack gap={5} align="stretch">
+            <HStack gap={2} align="center">
+                <FiZap/>
+                <Heading size="lg">Practice</Heading>
+            </HStack>
+
+            <Text color="gray.500" fontSize="sm">
+                Translate the following sentences into Chinese using the correct translation of the underlined word.
+            </Text>
+
+            <VStack gap={3}>
+                {sentences.map((sentence, index) => (
+                    <Box
+                        key={index}
+                        bg="white"
+                        borderRadius="lg"
+                        borderWidth="1px"
+                        borderColor="gray.100"
+                        p={4}
+                    >
+                        <Text fontSize="md" mb={2} color="gray.700">
+                            <Text as="span" fontWeight="semibold" color="blue.600" mr={1}>
+                                {index + 1}.
+                            </Text>
+                            {sentence}
+                        </Text>
+                        <Input
+                            placeholder="Your Chinese translation..."
+                            value={translations[index]}
+                            onChange={(e} => handleInputChange(index, e.target.value)}
+                            size="md"
+                            mt={1}
+                        />
+                    </Box>
+                ))}
+            </VStack>
+
+            <HStack justify="flex-end">
+                <Button
+                    colorPalette="blue"
+                    size="lg"
+                    onClick={handleSubmit}
+                    disabled={submitting}
+                    loading={submitting}
+                    loadingText="Submitting..."
+                >
+                    Submit
+                </Button>
+            </HStack>
+
+            <DialogRoot open={confirmOpen} onOpenChange={(e) => setConfirmOpen(e.open)}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Incomplete translations</DialogTitle>
+                    </DialogHeader>
+                    <DialogBody>
+                        <Text>You've left some translations blank. Submit anyway?</Text>
+                    </DialogBody>
+                    <DialogFooter>
+                        <DialogActionTrigger asChild>
+                            <Button variant="outline">Go back</Button>
+                        </DialogActionTrigger>
+                        <Button colorPalette="blue" onClick={() => { setConfirmOpen(false); doSubmit(); }}>Submit</Button>
+                    </DialogFooter>
+                </DialogContent>
+            </DialogRoot>
+        </VStack>
+    );
 }

--- a/src/components/practice/PracticePage.jsx
+++ b/src/components/practice/PracticePage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-    Box, Button, Input, List, Spinner, Text, VStack, HStack, Heading,
+    Box, Button, Input, Spinner, Text, VStack, HStack, Heading,
     DialogRoot, DialogContent, DialogHeader,
     DialogBody, DialogFooter, DialogTitle, DialogActionTrigger
 } from "@chakra-ui/react";
@@ -73,6 +73,11 @@ export function PracticePage({onReview}) {
         else doSubmit();
     };
 
+    const handleConfirmSubmit = () => {
+        setConfirmOpen(false);
+        doSubmit();
+    };
+
     if (gettingSentences) {
         return (
             <VStack
@@ -120,7 +125,7 @@ export function PracticePage({onReview}) {
                         <Input
                             placeholder="Your Chinese translation..."
                             value={translations[index]}
-                            onChange={(e} => handleInputChange(index, e.target.value)}
+                            onChange={(e) => handleInputChange(index, e.target.value)}
                             size="md"
                             mt={1}
                         />
@@ -153,7 +158,7 @@ export function PracticePage({onReview}) {
                         <DialogActionTrigger asChild>
                             <Button variant="outline">Go back</Button>
                         </DialogActionTrigger>
-                        <Button colorPalette="blue" onClick={() => { setConfirmOpen(false); doSubmit(); }}>Submit</Button>
+                        <Button colorPalette="blue" onClick={handleConfirmSubmit}>Submit</Button>
                     </DialogFooter>
                 </DialogContent>
             </DialogRoot>

--- a/src/components/practice/WelcomePage.jsx
+++ b/src/components/practice/WelcomePage.jsx
@@ -1,14 +1,44 @@
-import {Button, Text} from "@chakra-ui/react";
+import {Button, VStack, Heading, Text, HStack} from "@chakra-ui/react";
 import {useNavigate} from "react-router-dom";
-import {FiArrowLeft} from "react-icons/fi";
+import {FiArrowLeft, FiZap} from "react-icons/fi";
 
 export default function WelcomePage({onStart}) {
     const navigate = useNavigate();
     return (
-        <>
-            <Button variant="ghost" size="sm" onClick={() => navigate("/")}><FiArrowLeft/> Home</Button>
-            <Text>From here you can start practicing translating Chinese sentences</Text>
-            <Button colorPalette="blue" variant="subtle" onClick={onStart}>Start</Button>
-        </>
+        <VStack gap={5} align="stretch">
+            <HStack justify="space-between" align="center">
+                <Button variant="ghost" size="sm" onClick={() => navigate("/")} colorPalette="blue">
+                    <FiArrowLeft/> Home
+                </Button>
+                <HStack gap={2} align="center">
+                    <FiZap/>
+                    <Heading size="lg">Practice</Heading>
+                </HStack>
+                <!-- spacer so heading is centred -->
+                <Box as="span" w="68px" />
+            </HStack>
+
+            <VStack
+                align="center"
+                py={12}
+                bg="white"
+                borderRadius="xl"
+                borderWidth="1px"
+                borderColor="gray.100"
+                gap={4}
+            >
+                <Text fontSize="4xl">🐩</Text>
+                <Heading size="md" color="gray.700">
+                    Ready to practice?
+                </Heading>
+                <Text color="gray.500" fontSize="sm" textAlign="center" maxW="320px">
+                    Translate Chinese sentences using your vocabulary words.
+                    You’ll get AI-powered feedback after each session.
+                </Text>
+                <Button colorPalette="blue" size="lg" onClick={onStart} px={8}>
+                    Start Practice
+                </Button>
+            </VStack>
+        </VStack>
     );
 }

--- a/src/components/practice/WelcomePage.jsx
+++ b/src/components/practice/WelcomePage.jsx
@@ -1,20 +1,20 @@
-import {Button, VStack, Heading, Text, HStack} from "@chakra-ui/react";
+import {Button, VStack, Heading, Text, HStack, Box} from "@chakra-ui/react";
 import {useNavigate} from "react-router-dom";
-import {FiArrowLeft, FiZap} from "react-icons/fi";
+import {FiArrowLeft, FiZip} from "react-icons/fi";
 
 export default function WelcomePage({onStart}) {
     const navigate = useNavigate();
     return (
         <VStack gap={5} align="stretch">
-            <HStack justify="space-between" align="center">
+             <HStack justify="space-between" align="center">
                 <Button variant="ghost" size="sm" onClick={() => navigate("/")} colorPalette="blue">
                     <FiArrowLeft/> Home
                 </Button>
                 <HStack gap={2} align="center">
-                    <FiZap/>
+                    <FiZip/>
                     <Heading size="lg">Practice</Heading>
                 </HStack>
-                <!-- spacer so heading is centred -->
+                {/* spacer so heading is centred */}
                 <Box as="span" w="68px" />
             </HStack>
 

--- a/src/components/vocabulary/VocabularyList.jsx
+++ b/src/components/vocabulary/VocabularyList.jsx
@@ -61,6 +61,7 @@ export function VocabularyList({items, onDelete}) {
             {pageCount > 1 && (
                 <HStack mt={4} justify="center" gap={3} align="center">
                     <Button
+                        aria-label="Previous page"
                         variant="outline"
                         size="sm"
                         colorPalette="blue"
@@ -73,6 +74,7 @@ export function VocabularyList({items, onDelete}) {
                         {page + 1} / {pageCount}
                     </Text>
                     <Button
+                        aria-label="Next page"
                         variant="outline"
                         size="sm"
                         colorPalette="blue"

--- a/src/components/vocabulary/VocabularyList.jsx
+++ b/src/components/vocabulary/VocabularyList.jsx
@@ -6,6 +6,7 @@ import {
     Text,
     Button,
     HStack,
+    Flex,
 } from "@chakra-ui/react";
 
 const PAGE_SIZE = 10;
@@ -17,49 +18,71 @@ export function VocabularyList({items, onDelete}) {
     const pageItems = items.slice(start, start + PAGE_SIZE);
     const pageCount = Math.ceil(items.length / PAGE_SIZE);
 
+    if (items.length === 0) {
+        return (
+            <Box
+                textAlign="center"
+                py={12}
+                color="gray.400"
+                bg="white"
+                borderRadius="xl"
+                borderWidth="1px"
+                borderColor="gray.100"
+            >
+                <Text fontSize="3xl" mb={2}>💄</Text>
+                <Text fontSize="md">No words yet. Add your first word!</Text>
+            </Box>
+        );
+    }
+
     return (
         <>
-            <SimpleGrid columns={{base: 1, md: 2}} spacing={4}>
+            <SimpleGrid columns={{base: 1, md: 2}} gap={3}>
                 {pageItems.map((item, index) => (
-                    <Box
+                    <Flex
                         key={start + index}
-                        p={4}
+                        align="center"
+                        justify="space-between"
+                        px={4}
+                        py={3}
+                        bg="white"
+                        borderRadius="lg"
                         borderWidth="1px"
-                        borderRadius="md"
-                        textAlign="center"
-                        m={2}
+                        borderColor="gray.100"
+                        _hover={{borderColor: "blue.200", boxShadow: "sm"}}
+                        transition="all 0.15s"
                     >
-                        <Text>{item}</Text>
-                        <RemoveWordDialog
-                            word={item}
-                            onDelete={onDelete}
-                            style={{position: "absolute", top: 2, right: 2}}
-                        />
-                    </Box>
+                        <Text fontSize="lg" fontWeight="medium">{item}</Text>
+                        <RemoveWordDialog word={item} onDelete={onDelete}/>
+                    </Flex>
                 ))}
             </SimpleGrid>
 
-            <HStack mt={4} justify="center">
-                <Button
-                    variant="ghost"
-                    onClick={() => setPage(p => p - 1)}
-                    disabled={page === 0}
-                >
-                    ◀
-                </Button>
-
-                <Text>
-                    {page + 1} / {pageCount}
-                </Text>
-
-                <Button
-                    variant="ghost"
-                    onClick={() => setPage(p => p + 1)}
-                    disabled={page === pageCount - 1}
-                >
-                    ▶
-                </Button>
-            </HStack>
+            {pageCount > 1 && (
+                <HStack mt={4} justify="center" gap={3} align="center">
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        colorPalette="blue"
+                        onClick={() => setPage(p => p - 1)}
+                        disabled={page === 0}
+                    >
+                        ◐
+                    </Button>
+                    <Text fontSize="sm" color="gray.500">
+                        {page + 1} / {pageCount}
+                    </Text>
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        colorPalette="blue"
+                        onClick={() => setPage(p => p + 1)}
+                        disabled={page === pageCount - 1}
+                    >
+                        ◒
+                    </Button>
+                </HStack>
+            )}
         </>
     );
 }

--- a/src/components/vocabulary/VocabularyPage.jsx
+++ b/src/components/vocabulary/VocabularyPage.jsx
@@ -1,10 +1,10 @@
 import {AddWordDialog} from "./AddWordDialog.jsx";
-import {Spinner, Button} from "@chakra-ui/react";
+import {Spinner, Button, VStack, Heading, HStack, Text} from "@chakra-ui/react";
 import {VocabularyList} from "./VocabularyList.jsx";
 import {useEffect, useState} from "react";
 import {fetchVocabulary} from "../../services/vocabularyService.js";
 import {useNavigate} from "react-router-dom";
-import {FiArrowLeft} from "react-icons/fi";
+import {FiArrowLeft, FiBook} from "react-icons/fi";
 
 export default function VocabularyPage() {
 
@@ -19,7 +19,6 @@ export default function VocabularyPage() {
                 setLoadingVocabulary(false);
             })
             .catch(err => {
-                // Handle error (show message, etc.)
                 console.error(err);
             });
     }
@@ -29,13 +28,30 @@ export default function VocabularyPage() {
     }, []);
 
     return (
-        <>
-            <Button variant="ghost" size="sm" onClick={() => navigate("/")}><FiArrowLeft/> Home</Button>
-            <AddWordDialog onAdd={refresh}/>
+        <VStack gap={5} align="stretch">
+            <HStack justify="space-between" align="center">
+                <Button variant="ghost" size="sm" onClick={() => navigate("/")} colorPalette="blue">
+                    <FiArrowLeft/> Home
+                </Button>
+                <HStack gap={2} align="center">
+                    <FiBook />
+                    <Heading size="lg">Vocabulary</Heading>
+                    <Text color="gray.400" fontSize="sm">
+                        {items.length} words
+                    </Text>
+                </HStack>
+                <AddWordDialog onAdd={refresh}/>
+            </HStack>
+
             {
-                loadingVocabulary ? (<Spinner/>) :
-                    (<VocabularyList items={items} onDelete={refresh}/>)
+                loadingVocabulary ? (
+                    <VStack align="center" py={10}>
+                        <Spinner size="xl" color="blue.500"/>
+                    </VStack>
+                ) : (
+                    <VocabularyList items={items} onDelete={refresh}/>
+                )
             }
-        </>
+        </VStack>
     );
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,11 +1,37 @@
 import {createRoot} from 'react-dom/client'
 import App from './App.jsx'
-import {ChakraProvider, defaultSystem} from "@chakra-ui/react";
+import {ChakraProvider, createSystem, defaultConfig} from "@chakra-ui/react";
 import {BrowserRouter} from "react-router-dom";
 import {Toaster} from "./components/ui/toaster";
 
+const system = createSystem(defaultConfig, {
+    theme: {
+        tokens: {
+            colors: {
+                brand: {
+                    50:  { value: "#f0f4ff" },
+                    100: { value: "#dbe4ff" },
+                    200: { value: "#aac0fe" },
+                    300: { value: "#749efc" },
+                    400: { value: "#447ef1" },
+                    500: { value: "#3262e9" },
+                    600: { value: "#254ad3" },
+                    700: { value: "#1d36a7" },
+                    800: { value: "#162580" },
+                    900: { value: "#0f1756" },
+                },
+            },
+        },
+        semanticTokens: {
+            colors: {
+                "bg-canvas": { value: { _light: "#f8fafc", _dark: "#0f1127" } },
+            },
+        },
+    },
+});
+
 createRoot(document.getElementById('root')).render(
-    <ChakraProvider value={defaultSystem}>
+    <ChakraProvider value={system}>
         <BrowserRouter>
             <App/>
             <Toaster/>

--- a/src/tests/components/vocabulary/VocabularyList.test.jsx
+++ b/src/tests/components/vocabulary/VocabularyList.test.jsx
@@ -17,11 +17,11 @@ import {ChakraProvider, defaultSystem} from "@chakra-ui/react";
 test("renders all words in the list", () => {
     render(
         <ChakraProvider value={defaultSystem}>
-            <VocabularyList items={["你好", "世界"]}/>
+            <VocabularyList items={["你好", "$O�ׂ"]}/>
         </ChakraProvider>
     );
     expect(screen.getByText("你好")).toBeInTheDocument();
-    expect(screen.getByText("世界")).toBeInTheDocument();
+    expect(screen.getByText("$O0Ԃ")).toBeInTheDocument();
 });
 
 test("paginates long word lists", async () => {
@@ -37,8 +37,7 @@ test("paginates long word lists", async () => {
     expect(screen.queryByText("Word 11")).not.toBeInTheDocument();
 
     act(() => {
-        const nextButton = screen.getByText("▶");
-        nextButton.click();
+        screen.getByRole("button", {name: /next page/i}).click();
     });
 
     expect(await screen.getByText("Word 11")).toBeInTheDocument();

--- a/src/tests/components/vocabulary/VocabularyList.test.jsx
+++ b/src/tests/components/vocabulary/VocabularyList.test.jsx
@@ -17,11 +17,11 @@ import {ChakraProvider, defaultSystem} from "@chakra-ui/react";
 test("renders all words in the list", () => {
     render(
         <ChakraProvider value={defaultSystem}>
-            <VocabularyList items={["你好", "$O�ׂ"]}/>
+            <VocabularyList items={["hello", "world"]}/>
         </ChakraProvider>
     );
-    expect(screen.getByText("你好")).toBeInTheDocument();
-    expect(screen.getByText("$O0Ԃ")).toBeInTheDocument();
+    expect(screen.getByText("hello")).toBeInTheDocument();
+    expect(screen.getByText("world")).toBeInTheDocument();
 });
 
 test("paginates long word lists", async () => {


### PR DESCRIPTION
## Summary
Resolves #115 — implements a clean, minimal design across the entire app using Chakra UI v3. Works on both desktop and mobile.

---

## What changed

### 🎨 Theme & global styles (`main.jsx`, `App.css`)
- Created a custom Chakra `createSystem` theme with a `brand` blue color palette
- Added a global CSS reset, `background-color: #f8fafc` body background (light grey canvas)
- Styled the AWS Amplify auth screen to be vertically centred on the canvas
- Added `.page-wrapper` utility class

### 🏗️ Layout (`App.jsx`)
- Wrapped page content in a `<Container maxW="800px">` so content never stretches awkwardly on wide screens
- Applied a subtle grey background to the full viewport

### 🔝 Header (`Header.jsx`)
- Made the header **sticky** (`position: sticky; top: 0`) with a white background and a subtle shadow
- Added a dragon emoji next to the 每日龙 title for personality
- Username label hidden on mobile (`display: { base: 'none', sm: 'block' }`) to keep the bar uncluttered
- Sign-out button keeps its label visible as an icon-only button on small screens

### 🏠 Home (`Home.jsx`)
- Replaced plain text buttons with **feature cards** (white, rounded, hover lift effect)
- Each card has an icon (react-icons), a title, and a one-line description
- Cards wrap responsively via `HStack flexWrap="wrap"`

### 📚 VocabularyPage (`VocabularyPage.jsx`)
- Replaced flat layout with a proper **top bar**: back button on the left, title + word count in the centre, Add Word button on the right
- Loading spinner is now centred and coloured

### 📋 VocabularyList (`VocabularyList.jsx`)
- Each word is now a **row card** (white, rounded, hover border highlight) with the delete button aligned to the right
- Added an **empty state** (📔 icon + message) when the vocabulary is empty
- Pagination only renders when there is more than one page
- Pagination buttons styled with `variant="outline" colorPalette="blue"`

### ⚡ WelcomePage (`WelcomePage.jsx`)
- Replaced bare text + button with a centred **hero card** (white rounded box, emoji, description text)
- Added a nav top bar consistent with VocabularyPage

### 🧩 PracticePage (`PracticePage.jsx`)
- Loading state is now a centred white card with a spinner (instead of raw text + spinner inline)
- Each sentence + its translation input is wrapped in its own **white card**
- Sentence number badge coloured in blue
- Submit button moved to the right, uses `size="lg"` and Chakra's `loading` / `loadingText` props (removes the separate inline spinner + text)

---

## Screenshots (expected)
| Screen | Desktop | Mobile |
|--------|---------|--------|
| Home | Feature cards side-by-side | Cards stack vertically |
| Vocabulary | Row cards in 2 columns | Single column |
| Practice | Sentence cards, submit bottom-right | Full-width cards |

---

## Testing checklist
- [ ] App loads and auth screen is centred
- [ ] Header is sticky on scroll
- [ ] Home page shows two feature cards; clicking navigates correctly
- [ ] Vocabulary page shows word count, empty state, and paginated list
- [ ] Practice welcome page shows hero card and Start button
- [ ] Practice page renders sentence cards and submit works
- [ ] Review page renders correctly (unchanged)
- [ ] No regressions on mobile (375 px viewport)
