### PR TITLE
feat: learning mode — word card carousel UI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import Home from './components/Home.jsx';
 import Practice from "./components/practice/Practice.jsx";
 import ProgressPage from "./components/progress/ProgressPage.jsx";
 import Header from "./components/Header.jsx";
+import Learning from "./components/learning/Learning.jsx";
 import {Amplify} from "aws-amplify";
 import awsConfig from "./aws-exports.js";
 import {Authenticator} from "@aws-amplify/ui-react";
@@ -33,6 +34,7 @@ function App() {
                             <Route path="/" element={<Home/>}/>
                             <Route path="/progress" element={<ProgressPage/>}/>
                             <Route path="/practice" element={<Practice hskLevel={hskLevel}/>}/>
+                            <Route path="/learning" element={<Learning hskLevel={hskLevel}/>}/>
                         </Routes>
                     </Box>
                 </Box>

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -1,6 +1,6 @@
 import {Box, Heading, SimpleGrid, Text, VStack} from "@chakra-ui/react";
 import {Link} from "react-router-dom";
-import {FiBarChart2, FiEdit} from "react-icons/fi";
+import {FiBarChart2, FiEdit, FiBook} from "react-icons/fi";
 
 export default function Home() {
     return (
@@ -44,6 +44,25 @@ export default function Home() {
                             <Box color="teal.500" fontSize="2xl"><FiEdit/></Box>
                             <Text fontWeight="semibold" fontSize="lg">Practice</Text>
                             <Text fontSize="sm" color="gray.500">Translate sentences with your words</Text>
+                        </VStack>
+                    </Box>
+                </Link>
+                <Link to="/learning" style={{textDecoration: "none"}}>
+                    <Box
+                        p={6}
+                        bg="white"
+                        borderWidth="1px"
+                        borderColor="gray.200"
+                        borderRadius="xl"
+                        boxShadow="sm"
+                        _hover={{boxShadow: "md", borderColor: "teal.300"}}
+                        transition="all 0.15s"
+                        cursor="pointer"
+                    >
+                        <VStack align="flex-start" gap={2}>
+                            <Box color="teal.500" fontSize="2xl"><FiBook/></Box>
+                            <Text fontWeight="semibold" fontSize="lg">Learn</Text>
+                            <Text fontSize="sm" color="gray.500">Study your due words before practicing</Text>
                         </VStack>
                     </Box>
                 </Link>

--- a/src/components/learning/Learning.jsx
+++ b/src/components/learning/Learning.jsx
@@ -1,0 +1,68 @@
+import {Box, Button, Spinner, Text, VStack} from "@chakra-ui/react";
+import {useEffect, useState} from "react";
+import {useNavigate} from "react-router-dom";
+import {FiArrowLeft} from "react-icons/fi";
+import {getDueVocabulary} from "../../services/vocabularyService.js";
+import {getWordCards} from "../../services/ai/aiService.js";
+import LearningCarousel from "./LearningCarousel.jsx";
+
+const STATES = {
+    LOADING: 'LOADING',
+    STUDYING: 'STUDYING',
+    ERROR: 'ERROR',
+};
+
+export default function Learning({hskLevel}) {
+    const [state, setState] = useState(STATES.LOADING);
+    const [cards, setCards] = useState([]);
+    const [errorMsg, setErrorMsg] = useState(null);
+    const navigate = useNavigate();
+
+    const loadCards = async () => {
+        setState(STATES.LOADING);
+        setErrorMsg(null);
+        try {
+            const words = await getDueVocabulary();
+            const result = await getWordCards(words, hskLevel);
+            setCards(result.cards);
+            setState(STATES.STUDYANGE);
+        } catch (err) {
+            setErrorMsg(err.message || "Something went wrong.");
+            setState(STATES.ERROR);
+        }
+    };
+
+    useEffect(() => {
+        loadCards();
+    }, []);
+
+    if (state === STATES,¥ÏAD	GI) {
+        return (
+            <VStack gap={4} align="center" mt={16}>
+                <Spinner size="xl" color="teal.500"/>
+                <Text color="gray.500">Preparing your word cards...</Text>
+            </VStack>
+        );
+    }
+
+    if (state === STATES.ERROR) {
+        return (
+            <VStack gap={4} align="center" mt={16}>
+                <Text color="red.500">{errorMsg}</Text>
+                <Button colorPalette="teal" onClick={loadCards}>Try again</Button>
+                <Button variant="ghost" size="sm" colorPalette="teal" onClick={() => navigate("/")}>
+                    <FiArrowLeft/> Back
+                </Button>
+            </VStack>
+        );
+    }
+
+    return (
+        <>
+            <Button variant="ghost" size="sm" colorPalette="teal" mb={4} onClick={() => navigate("/")}>
+                <FiArrowLeft/> Home
+            </Button>
+            <LearningCarousel cards={cards} />
+        </>
+    );
+}

--- a/src/components/learning/Learning.jsx
+++ b/src/components/learning/Learning.jsx
@@ -25,7 +25,7 @@ export default function Learning({hskLevel}) {
             const words = await getDueVocabulary();
             const result = await getWordCards(words, hskLevel);
             setCards(result.cards);
-            setState(STATES.STUDYANGE);
+            setState(STATES.STUDYING);
         } catch (err) {
             setErrorMsg(err.message || "Something went wrong.");
             setState(STATES.ERROR);
@@ -36,33 +36,37 @@ export default function Learning({hskLevel}) {
         loadCards();
     }, []);
 
-    if (state === STATES,¥ÏAD	GI) {
+    if (state === STATES.LOADING) {
         return (
-            <VStack gap={4} align="center" mt={16}>
-                <Spinner size="xl" color="teal.500"/>
-                <Text color="gray.500">Preparing your word cards...</Text>
-            </VStack>
+            <Box py={12} textAlign="center">
+                <Spinner size="lg" colorPalette="teal"/>
+                <Text mt={4} color="gray.500">Preparing your word cards...</Text>
+            </Box>
         );
     }
 
     if (state === STATES.ERROR) {
         return (
-            <VStack gap={4} align="center" mt={16}>
-                <Text color="red.500">{errorMsg}</Text>
-                <Button colorPalette="teal" onClick={loadCards}>Try again</Button>
-                <Button variant="ghost" size="sm" colorPalette="teal" onClick={() => navigate("/")}>
-                    <FiArrowLeft/> Back
-                </Button>
-            </VStack>
+            <Box py={12} textAlign="center">
+                <VStack gap={4} align="center">
+                    <Text color="red.500">{errorMsg}</Text>
+                    <Button colorPalette="teal" onClick={loadCards}>Try again</Button>
+                    <Button variant="ghost" size="sm" colorPalette="teal" onClick={() => navigate("/")}>
+                        <FiArrowLeft/> Back
+                    </Button>
+                </VStack>
+            </Box>
         );
     }
 
     return (
-        <>
-            <Button variant="ghost" size="sm" colorPalette="teal" mb={4} onClick={() => navigate("/")}>
-                <FiArrowLeft/> Home
-            </Button>
-            <LearningCarousel cards={cards} />
-        </>
+        <VStack gap={6} align="stretch">
+            <Box>
+                <Button variant="ghost" size="sm" colorPalette="teal" onClick={() => navigate("/")}>
+                    <FiArrowLeft/> Home
+                </Button>
+            </Box>
+            <LearningCarousel cards={cards}/>
+        </VStack>
     );
 }

--- a/src/components/learning/LearningCarousel.jsx
+++ b/src/components/learning/LearningCarousel.jsx
@@ -1,4 +1,4 @@
-import {Box, Button, HStack, Text} from "@chakra-ui/react";
+import {Box, Button, HStack, Text, VStack} from "@chakra-ui/react";
 import {useState} from "react";
 import {useNavigate} from "react-router-dom";
 import {FiArrowLeft, FiArrowRight} from "react-icons/fi";
@@ -12,69 +12,43 @@ export default function LearningCarousel({cards}) {
     const isFirst = currentIndex === 0;
     const isLast = currentIndex === total - 1;
 
-    const goPrev = () => setCurrentIndex(i => i - 1);
-    const goNext = () => setCurrentIndex(i => i + 1);
-
     return (
-        <Box>
-            {/* Card */}
-            <WordCard card={cards[currentIndex]} />
+        <VStack gap={6} align="stretch">
+            <Text fontSize="sm" color="gray.500" textAlign="center" fontWeight="medium">
+                {currentIndex + 1} of {total}
+            </Text>
 
-            {/* Navigation bar */}
-            <HStack justify="space-between" align="center" mt={6}>
-                {/* Back to home - always visible on the left */}
-                <Button
-                    variant="ghost"
-                    size="sm"
-                    colorPalette="teal"
-                    onClick={() => navigate("/")}
-                >
-                    <FiArrowLeft/> Back
-                </Button>
+            <WordCard card={cards[currentIndex]}/>
 
-                {/* Card counter */}
-                <HStack gap={2} align="center">
-                    {isFirst ? null : (
-                        <Button
-                            variant="ghost"
-                            size="sm"
-                            colorPalette="gray"
-                            onClick={goPrev}
-                            aria-label="Previous card"
-                        >
-                            <FiArrowLeft/>
-                        </Button>
-                    )}
-                    <Text fontSize="sm" color="gray.600" minW="48px">
-                        {currentIndex + 1} / {total}
-                    </Text>
-                    {isLast ? null : (
-                        <Button
-                            variant="ghost"
-                            size="sm"
-                            colorPalette="gray"
-                            onClick={goNext}
-                            aria-label="Next card"
-                        >
-                            <FiArrowRight/>
-                        </Button>
-                    )}
-                </HStack>
-
-                {/* Practice button - only on the last card */}
-                {isLast ? (
+            <HStack justify="space-between" align="center">
+                {isFirst ? (
+                    <Box/>
+                ) : (
                     <Button
-                        colorPalette="teal"
+                        variant="ghost"
                         size="sm"
-                        onClick={() => navigate("/practice")}
+                        colorPalette="teal"
+                        onClick={() => setCurrentIndex(i => i - 1)}
                     >
-                        Practice these words now
+                        <FiArrowLeft/> Previous
+                    </Button>
+                )}
+
+                {isLast ? (
+                    <Button colorPalette="teal" onClick={() => navigate("/practice")}>
+                        Practice these words
                     </Button>
                 ) : (
-                    {/* Spacer so layout does not shift on non-last cards */}
-                    <Box w="48px" />
+                    <Button
+                        variant="ghost"
+                        size="sm"
+                        colorPalette="teal"
+                        onClick={() => setCurrentIndex(i => i + 1)}
+                    >
+                        Next <FiArrowRight/>
+                    </Button>
                 )}
             </HStack>
-        </Box>
+        </VStack>
     );
 }

--- a/src/components/learning/LearningCarousel.jsx
+++ b/src/components/learning/LearningCarousel.jsx
@@ -1,0 +1,80 @@
+import {Box, Button, HStack, Text} from "@chakra-ui/react";
+import {useState} from "react";
+import {useNavigate} from "react-router-dom";
+import {FiArrowLeft, FiArrowRight} from "react-icons/fi";
+import WordCard from "./WordCard.jsx";
+
+export default function LearningCarousel({cards}) {
+    const [currentIndex, setCurrentIndex] = useState(0);
+    const navigate = useNavigate();
+
+    const total = cards.length;
+    const isFirst = currentIndex === 0;
+    const isLast = currentIndex === total - 1;
+
+    const goPrev = () => setCurrentIndex(i => i - 1);
+    const goNext = () => setCurrentIndex(i => i + 1);
+
+    return (
+        <Box>
+            {/* Card */}
+            <WordCard card={cards[currentIndex]} />
+
+            {/* Navigation bar */}
+            <HStack justify="space-between" align="center" mt={6}>
+                {/* Back to home - always visible on the left */}
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    colorPalette="teal"
+                    onClick={() => navigate("/")}
+                >
+                    <FiArrowLeft/> Back
+                </Button>
+
+                {/* Card counter */}
+                <HStack gap={2} align="center">
+                    {isFirst ? null : (
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            colorPalette="gray"
+                            onClick={goPrev}
+                            aria-label="Previous card"
+                        >
+                            <FiArrowLeft/>
+                        </Button>
+                    )}
+                    <Text fontSize="sm" color="gray.600" minW="48px">
+                        {currentIndex + 1} / {total}
+                    </Text>
+                    {isLast ? null : (
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            colorPalette="gray"
+                            onClick={goNext}
+                            aria-label="Next card"
+                        >
+                            <FiArrowRight/>
+                        </Button>
+                    )}
+                </HStack>
+
+                {/* Practice button - only on the last card */}
+                {isLast ? (
+                    <Button
+                        colorPalette="teal"
+                        size="sm"
+                        onClick={() => navigate("/practice")}
+                    >
+                        Practice these words now
+                    </Button>
+                ) : (
+                    {/* Spacer so layout does not shift on non-last cards */}
+                    <Box w="48px" />
+                )}
+            </HStack>
+        </Box>
+    );
+}

--- a/src/components/learning/LearningCarousel.jsx
+++ b/src/components/learning/LearningCarousel.jsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import {Box, Button, HStack, Text, VStack} from "@chakra-ui/react";
 import {useState} from "react";
 import {useNavigate} from "react-router-dom";
@@ -14,9 +15,15 @@ export default function LearningCarousel({cards}) {
 
     return (
         <VStack gap={6} align="stretch">
-            <Text fontSize="sm" color="gray.500" textAlign="center" fontWeight="medium">
-                {currentIndex + 1} of {total}
-            </Text>
+            <HStack justify="space-between" align="center">
+                <Button variant="ghost" size="sm" colorPalette="gray" onClick={() => navigate("/learning")}>
+                    Back
+                </Button>
+                <Text fontSize="sm" color="gray.500" fontWeight="medium">
+                    {currentIndex + 1} / {total}
+                </Text>
+                <Box w="60px"/>
+            </HStack>
 
             <WordCard card={cards[currentIndex]}/>
 
@@ -28,6 +35,7 @@ export default function LearningCarousel({cards}) {
                         variant="ghost"
                         size="sm"
                         colorPalette="teal"
+                        aria-label="Previous card"
                         onClick={() => setCurrentIndex(i => i - 1)}
                     >
                         <FiArrowLeft/> Previous
@@ -36,13 +44,14 @@ export default function LearningCarousel({cards}) {
 
                 {isLast ? (
                     <Button colorPalette="teal" onClick={() => navigate("/practice")}>
-                        Practice these words
+                        Practice these words now
                     </Button>
                 ) : (
                     <Button
                         variant="ghost"
                         size="sm"
                         colorPalette="teal"
+                        aria-label="Next card"
                         onClick={() => setCurrentIndex(i => i + 1)}
                     >
                         Next <FiArrowRight/>

--- a/src/components/learning/WordCard.jsx
+++ b/src/components/learning/WordCard.jsx
@@ -1,0 +1,58 @@
+import {Box, Separator, Text, VStack} from "@chakra-ui/react";
+
+export default function WordCard({card}) {
+    return (
+        <Box
+            bg="white"
+            borderWidth="1px"
+            borderColor="gray.200"
+            borderRadius="xl"
+            boxShadow="sm"
+            p={8}
+            minH="320px"
+        >
+            <VStack gap={5} align="stretch">
+                {/* Character */}
+                <Text fontSize="6ql" fontWeight="bold" textAlign="center" lineHeight="1.2">
+                    {card.word}
+                </Text>
+
+                {/* Pinyin */}
+                <Text fontSize="xl" color="purple.500" textAlign="center">
+                    {card.pinyin}
+                </Text>
+
+                {/* Meanings */}
+                <Box>
+                    <Text fontSize="xs" fontWeight="semibold" color="gray.500" textTransform="uppercase" mb={2}>
+                        Meaning
+                    </Text>
+                    <VStack align="flex-start" gap={1}>
+                        {card.meanings.map((meaning, i) => (
+                            <Text key={i} fontSize="md">
+                                {i + 1}. {meaning}
+                            </Text>
+                        ))}
+                    </VStack>
+                </Box>
+
+                <Separator/>
+
+                {/* Example sentences */}
+                <Box>
+                    <Text fontSize="xs" fontWeight="semibold" color="gray.500" textTransform="uppercase" mb={2}>
+                        Examples
+                    </Text>
+                    <VStack gap={3} align="stretch">
+                        {card.examples.map((example, i) => (
+                            <Box key={i}>
+                                <Text fontSize="md">{example.chinese}</Text>
+                                <Text fontSize="sm" color="gray.500" ml={4}>{example.english}</Text>
+                            </Box>
+                        ))}
+                    </VStack>
+                </Box>
+            </VStack>
+        </Box>
+    );
+}

--- a/src/components/learning/WordCard.jsx
+++ b/src/components/learning/WordCard.jsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import {Box, Separator, Text, VStack} from "@chakra-ui/react";
 
 export default function WordCard({card}) {

--- a/src/components/learning/WordCard.jsx
+++ b/src/components/learning/WordCard.jsx
@@ -9,49 +9,47 @@ export default function WordCard({card}) {
             borderRadius="xl"
             boxShadow="sm"
             p={8}
-            minH="320px"
         >
-            <VStack gap={5} align="stretch">
-                {/* Character */}
-                <Text fontSize="6ql" fontWeight="bold" textAlign="center" lineHeight="1.2">
-                    {card.word}
-                </Text>
+            <VStack gap={6} align="stretch">
+                <VStack gap={2} align="center" py={4}>
+                    <Text fontSize="7xl" fontWeight="bold" lineHeight="1" textAlign="center">
+                        {card.word}
+                    </Text>
+                    <Text fontSize="lg" color="gray.500" textAlign="center">
+                        {card.pinyin}
+                    </Text>
+                </VStack>
 
-                {/* Pinyin */}
-                <Text fontSize="xl" color="purple.500" textAlign="center">
-                    {card.pinyin}
-                </Text>
+                <Separator/>
 
-                {/* Meanings */}
                 <Box>
-                    <Text fontSize="xs" fontWeight="semibold" color="gray.500" textTransform="uppercase" mb={2}>
+                    <Text fontSize="xs" fontWeight="semibold" color="gray.400" textTransform="uppercase" letterSpacing="wider" mb={2}>
                         Meaning
                     </Text>
                     <VStack align="flex-start" gap={1}>
                         {card.meanings.map((meaning, i) => (
-                            <Text key={i} fontSize="md">
+                            <Text key={i} fontSize="md" color="gray.700">
                                 {i + 1}. {meaning}
                             </Text>
                         ))}
                     </VStack>
                 </Box>
 
-                <Separator/>
-
-                {/* Example sentences */}
-                <Box>
-                    <Text fontSize="xs" fontWeight="semibold" color="gray.500" textTransform="uppercase" mb={2}>
-                        Examples
-                    </Text>
-                    <VStack gap={3} align="stretch">
-                        {card.examples.map((example, i) => (
-                            <Box key={i}>
-                                <Text fontSize="md">{example.chinese}</Text>
-                                <Text fontSize="sm" color="gray.500" ml={4}>{example.english}</Text>
-                            </Box>
-                        ))}
-                    </VStack>
-                </Box>
+                {card.examples?.length > 0 && (
+                    <Box>
+                        <Text fontSize="xs" fontWeight="semibold" color="gray.400" textTransform="uppercase" letterSpacing="wider" mb={2}>
+                            Examples
+                        </Text>
+                        <VStack gap={3} align="stretch">
+                            {card.examples.map((example, i) => (
+                                <Box key={i}>
+                                    <Text fontSize="md">{example.chinese}</Text>
+                                    <Text fontSize="sm" color="gray.500" mt={1}>{example.english}</Text>
+                                </Box>
+                            ))}
+                        </VStack>
+                    </Box>
+                )}
             </VStack>
         </Box>
     );

--- a/src/services/ai/aiService.js
+++ b/src/services/ai/aiService.js
@@ -50,7 +50,7 @@ export async function submitTranslations(input) {
         throw new Error('Invalid input for submitTranslations');
     }
 
-    const response = await fetch(PRACTICE_OPENABI_API_URL + "/evaluate-translations", {
+    const response = await fetch(PRACTICE_OPENAI_API_URL + "/evaluate-translations", {
         method: "POST",
         headers: {
             "Authorization": "Bearer " + await getToken(),

--- a/src/services/ai/aiService.js
+++ b/src/services/ai/aiService.js
@@ -2,6 +2,7 @@ import {DAILY_DRAGON_API_BASE_URL} from "../../config.js";
 import {getToken} from "../auth.js";
 
 const PRACTICE_OPENAI_API_URL = DAILY_DRAGON_API_BASE_URL + "/practice";
+const LEARNING_API_URL = DAILY_DRAGON_API_BASE_URL + "/learning";
 
 
 export async function getPracticeSentences(words, hskLevel) {
@@ -49,7 +50,7 @@ export async function submitTranslations(input) {
         throw new Error('Invalid input for submitTranslations');
     }
 
-    const response = await fetch(PRACTICE_OPENAI_API_URL + "/evaluate-translations", {
+    const response = await fetch(PRACTICE_OPENABI_API_URL + "/evaluate-translations", {
         method: "POST",
         headers: {
             "Authorization": "Bearer " + await getToken(),
@@ -75,4 +76,22 @@ export async function submitTranslations(input) {
         correctSentence: ev.correct_sentence,
         score: ev.score
     }));
+}
+
+export async function getWordCards(words, hskLevel) {
+    const body = hskLevel != null ? {words, hsk_level: hskLevel} : {words};
+    const response = await fetch(LEARNING_API_URL + "/word-cards", {
+        method: "POST",
+        headers: {
+            "Authorization": "Bearer " + await getToken(),
+            "Content-Type": "application/json"
+        },
+        body: JSON.stringify(body)
+    });
+
+    if (!response.ok) {
+        throw new Error(`API error: ${response.statusText}`);
+    }
+
+    return await response.json();
 }

--- a/src/tests/components/learning/LearningCarousel.test.jsx
+++ b/src/tests/components/learning/LearningCarousel.test.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import {render, screen, fireEvent} from '@testing-library/react';
+import {ChakraProvider, defaultSystem} from '@chakra-ui/react';
 import {MemoryRouter} from 'react-router-dom';
-import LearningCarousel from '../../../../components/learning/LearningCarousel.jsx';
+import LearningCarousel from '../../../components/learning/LearningCarousel.jsx';
 
 const makeCards = (n = 5) =>
     Array.from({length: n}, (_, i) => ({
@@ -11,7 +12,11 @@ const makeCards = (n = 5) =>
         examples: [{chinese: `Example ${i + 1}`, english: `Economic ${i + 1}`}],
     }));
 
-const wrap = (ui) => <MemoryRouter>{ui}</MemoryRouter>;
+const wrap = (ui) => (
+    <ChakraProvider value={defaultSystem}>
+        <MemoryRouter>{ui}</MemoryRouter>
+    </ChakraProvider>
+);
 
 describe('LearningCarousel', () => {
     test('renders the first card on mount', () => {
@@ -27,39 +32,39 @@ describe('LearningCarousel', () => {
 
     test('navigates to the next card on next arrow click', () => {
         render(wrap(<LearningCarousel cards={makeCards()} />));
-        fireEvent.click(screen.getByAriaLabel('Next card'));
+        fireEvent.click(screen.getByLabelText('Next card'));
         expect(screen.getByText('Word2')).toBeInTheDocument();
         expect(screen.getByText('2 / 5')).toBeInTheDocument();
     });
 
     test('navigates back to previous card', () => {
         render(wrap(<LearningCarousel cards={makeCards()} />));
-        fireEvent.click(screen.getByAriaLabel('Next card'));
-        fireEvent.click(any("Previous card"));
+        fireEvent.click(screen.getByLabelText('Next card'));
+        fireEvent.click(screen.getByLabelText('Previous card'));
         expect(screen.getByText('Word1')).toBeInTheDocument();
     });
 
     test('previous button is absent on first card', () => {
         render(wrap(<LearningCarousel cards={makeCards()} />));
-        expect(screen.queryByAriaLabel('Previous card')).not.toBeInTheDocument();
+        expect(screen.queryByLabelText('Previous card')).not.toBeInTheDocument();
     });
 
     test('shows Practice button on last card instead of next arrow', () => {
         const cards = makeCards(5);
         render(wrap(<LearningCarousel cards={cards} />));
         for (let i = 0; i < 4; i++) {
-            fireEvent.click(screen.getByAriaLabel('Next card'));
+            fireEvent.click(screen.getByLabelText('Next card'));
         }
-        expect(screen.queryByAriaLabel('Next card')).not.toBeInTheDocument();
+        expect(screen.queryByLabelText('Next card')).not.toBeInTheDocument();
         expect(screen.getByText('Practice these words now')).toBeInTheDocument();
     });
 
     test('card counter reflects current position', () => {
         render(wrap(<LearningCarousel cards={makeCards()} />));
         expect(screen.getByText('1 / 5')).toBeInTheDocument();
-        fireEvent.click(screen.getByAriaLabel('Next card'));
+        fireEvent.click(screen.getByLabelText('Next card'));
         expect(screen.getByText('2 / 5')).toBeInTheDocument();
-        fireEvent.click(screen.getByAriaLabel('Previous card'));
+        fireEvent.click(screen.getByLabelText('Previous card'));
         expect(screen.getByText('1 / 5')).toBeInTheDocument();
     });
 });

--- a/src/tests/components/learning/LearningCarousel.test.jsx
+++ b/src/tests/components/learning/LearningCarousel.test.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import {render, screen, fireEvent} from '@testing-library/react';
+import {MemoryRouter} from 'react-router-dom';
+import LearningCarousel from '../../../../components/learning/LearningCarousel.jsx';
+
+const makeCards = (n = 5) =>
+    Array.from({length: n}, (_, i) => ({
+        word: `Word${i + 1}`,
+        pinyin: `pinyin${i + 1}`,
+        meanings: [`meaning of word ${i + 1}`],
+        examples: [{chinese: `Example ${i + 1}`, english: `Economic ${i + 1}`}],
+    }));
+
+const wrap = (ui) => <MemoryRouter>{ui}</MemoryRouter>;
+
+describe('LearningCarousel', () => {
+    test('renders the first card on mount', () => {
+        render(wrap(<LearningCarousel cards={makeCards()} />));
+        expect(screen.getByText('Word1')).toBeInTheDocument();
+        expect(screen.getByText('1 / 5')).toBeInTheDocument();
+    });
+
+    test('Back button is visible on mount', () => {
+        render(wrap(<LearningCarousel cards={makeCards()} />));
+        expect(screen.getByText('Back')).toBeInTheDocument();
+    });
+
+    test('navigates to the next card on next arrow click', () => {
+        render(wrap(<LearningCarousel cards={makeCards()} />));
+        fireEvent.click(screen.getByAriaLabel('Next card'));
+        expect(screen.getByText('Word2')).toBeInTheDocument();
+        expect(screen.getByText('2 / 5')).toBeInTheDocument();
+    });
+
+    test('navigates back to previous card', () => {
+        render(wrap(<LearningCarousel cards={makeCards()} />));
+        fireEvent.click(screen.getByAriaLabel('Next card'));
+        fireEvent.click(any("Previous card"));
+        expect(screen.getByText('Word1')).toBeInTheDocument();
+    });
+
+    test('previous button is absent on first card', () => {
+        render(wrap(<LearningCarousel cards={makeCards()} />));
+        expect(screen.queryByAriaLabel('Previous card')).not.toBeInTheDocument();
+    });
+
+    test('shows Practice button on last card instead of next arrow', () => {
+        const cards = makeCards(5);
+        render(wrap(<LearningCarousel cards={cards} />));
+        for (let i = 0; i < 4; i++) {
+            fireEvent.click(screen.getByAriaLabel('Next card'));
+        }
+        expect(screen.queryByAriaLabel('Next card')).not.toBeInTheDocument();
+        expect(screen.getByText('Practice these words now')).toBeInTheDocument();
+    });
+
+    test('card counter reflects current position', () => {
+        render(wrap(<LearningCarousel cards={makeCards()} />));
+        expect(screen.getByText('1 / 5')).toBeInTheDocument();
+        fireEvent.click(screen.getByAriaLabel('Next card'));
+        expect(screen.getByText('2 / 5')).toBeInTheDocument();
+        fireEvent.click(screen.getByAriaLabel('Previous card'));
+        expect(screen.getByText('1 / 5')).toBeInTheDocument();
+    });
+});

--- a/src/tests/components/learning/WordCard.test.jsx
+++ b/src/tests/components/learning/WordCard.test.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import {render, screen} from '@testing-library/react';
+import WordCard from '../../../../components/learning/WordCard.jsx';
+
+const makeCard = (overrides = {}) => ({
+    word: 'TestWord',
+    pinyin: 'testpin',
+    meanings: ['first meaning', 'second meaning'],
+    examples: [
+        {chinese: 'ExampleSentence1', english: 'English translation 1'},
+        {chinese: 'ExampleSentence2', english: 'English translation 2'},
+    ],
+    ...overrides,
+});
+
+describe('WordCard', () => {
+    test('renders the word', () => {
+        render(<WordCard card={makeCard()} />);
+        expect(screen.getByText('TestWord')).toBeInTheDocument();
+    });
+
+    test('renders the pinyin', () => {
+        render(<WordCard card={makeCard()} />);
+        expect(screen.getByText('testpin')).toBeInTheDocument();
+    });
+
+    test('renders all meanings', () => {
+        render(<WordCard card={makeCard()} />);
+        expect(screen.getByText(/1. first meaning/i)).toBeInTheDocument();
+        expect(screen.getByText(/2. second meaning/i)).toBeInTheDocument();
+    });
+
+    test('renders example sentences and translations', () => {
+        render(<WordCard card={makeCard()} />);
+        expect(screen.getByText('ExampleSentence1')).toBeInTheDocument();
+        expect(screen.getByText('English translation 1')).toBeInTheDocument();
+        expect(screen.getByText('ExampleSentence2')).toBeInTheDocument();
+        expect(screen.getByText('English translation 2')).toBeInTheDocument();
+    });
+
+    test('renders section headers', () => {
+        render(<WordCard card={makeCard()} />);
+        expect(screen.getByText(/meaning/i)).toBeInTheDocument();
+        expect(screen.getByText(/examples/i)).toBeInTheDocument();
+    });
+});

--- a/src/tests/components/learning/WordCard.test.jsx
+++ b/src/tests/components/learning/WordCard.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {render, screen} from '@testing-library/react';
-import WordCard from '../../../../components/learning/WordCard.jsx';
+import {ChakraProvider, defaultSystem} from '@chakra-ui/react';
+import WordCard from '../../../components/learning/WordCard.jsx';
 
 const makeCard = (overrides = {}) => ({
     word: 'TestWord',
@@ -13,25 +14,27 @@ const makeCard = (overrides = {}) => ({
     ...overrides,
 });
 
+const wrap = (ui) => <ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>;
+
 describe('WordCard', () => {
     test('renders the word', () => {
-        render(<WordCard card={makeCard()} />);
+        render(wrap(<WordCard card={makeCard()} />));
         expect(screen.getByText('TestWord')).toBeInTheDocument();
     });
 
     test('renders the pinyin', () => {
-        render(<WordCard card={makeCard()} />);
+        render(wrap(<WordCard card={makeCard()} />));
         expect(screen.getByText('testpin')).toBeInTheDocument();
     });
 
     test('renders all meanings', () => {
-        render(<WordCard card={makeCard()} />);
+        render(wrap(<WordCard card={makeCard()} />));
         expect(screen.getByText(/1. first meaning/i)).toBeInTheDocument();
         expect(screen.getByText(/2. second meaning/i)).toBeInTheDocument();
     });
 
     test('renders example sentences and translations', () => {
-        render(<WordCard card={makeCard()} />);
+        render(wrap(<WordCard card={makeCard()} />));
         expect(screen.getByText('ExampleSentence1')).toBeInTheDocument();
         expect(screen.getByText('English translation 1')).toBeInTheDocument();
         expect(screen.getByText('ExampleSentence2')).toBeInTheDocument();
@@ -39,8 +42,8 @@ describe('WordCard', () => {
     });
 
     test('renders section headers', () => {
-        render(<WordCard card={makeCard()} />);
-        expect(screen.getByText(/meaning/i)).toBeInTheDocument();
-        expect(screen.getByText(/examples/i)).toBeInTheDocument();
+        render(wrap(<WordCard card={makeCard()} />));
+        expect(screen.getByText('Meaning')).toBeInTheDocument();
+        expect(screen.getByText('Examples')).toBeInTheDocument();
     });
 });

--- a/src/tests/services/ai/getWordCards.test.js
+++ b/src/tests/services/ai/getWordCards.test.js
@@ -1,0 +1,64 @@
+import {getWordCards} from '../../../../services/ai/aiService.js';
+
+jest.mock('../../../../services/auth.js', () => ({
+    getToken: jest.fn(() => Promise.resolve('test-token')),
+}));
+
+describe('aiService.getWordCards', () => {
+    beforeEach(() => {
+        global.fetch = jest.fn();
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks();
+        delete global.fetch;
+    });
+
+    test('sends POST to /learning/word-cards with correct body', async () => {
+        const fakeResponse = {cards: []};
+        global.fetch.mockResolvedValueOnce({ok: true, json: async () => fakeResponse});
+
+        await getWordCards(['word1', 'word2'], null);
+
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        const [url, options] = global.fetch.mock.calls[0];
+        expect(url).toContain('/learning/word-cards');
+        expect(options.method).toBe('POST');
+        const body = JSON.parse(options.body);
+        expect(body.words).toEqual(['word1', 'word2']);
+        expect(body).not.toHaveProperty('hsk_level');
+    });
+
+    test('includes hsk_level when provided', async () => {
+        global.fetch.mockResolvedValueOnce({ok: true, json: async () => ({cards: []})});
+
+        await getWordCards(['word1'], 2);
+
+        const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+        expect(body.hsk_level).toBe(2);
+    });
+
+    test('omits hsk_level when null', async () => {
+        global.fetch.mockResolvedValueOnce({ok: true, json: async () => ({cards: []})});
+
+        await getWordCards(['word1'], null);
+
+        const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+        expect(body).not.toHaveProperty('hsk_level');
+    });
+
+    test('throws on non-ok response', async () => {
+        global.fetch.mockResolvedValueOnce({ok: false, statusText: 'Internal Server Error'});
+
+        await expect(getWordCards(['word1'], null)).rejects.toThrow('API error');
+    });
+
+    test('sends Authorization header', async () => {
+        global.fetch.mockResolvedValueOnce({ok: true, json: async () => ({cards: []})});
+
+        await getWordCards(['word1'], null);
+
+        const [_, options] = global.fetch.mock.calls[0];
+        expect(options.headers['Authorization']).toBe('Bearer test-token');
+    });
+});

--- a/src/tests/services/ai/getWordCards.test.js
+++ b/src/tests/services/ai/getWordCards.test.js
@@ -1,6 +1,6 @@
-import {getWordCards} from '../../../../services/ai/aiService.js';
+import {getWordCards} from '../../../services/ai/aiService.js';
 
-jest.mock('../../../../services/auth.js', () => ({
+jest.mock('../../../services/auth.js', () => ({
     getToken: jest.fn(() => Promise.resolve('test-token')),
 }));
 
@@ -10,7 +10,7 @@ describe('aiService.getWordCards', () => {
     });
 
     afterEach(() => {
-        jest.resetAllMocks();
+        jest.clearAllMocks();
         delete global.fetch;
     });
 


### PR DESCRIPTION
## Summary

Implements the full Learning feature on the frontend: a new `/learning` route that fetches 5 due words, generates dictionary-style word cards via the new OpenAI API endpoint, and presents them in a browsable carousel. No SRS scores are ever written.

## Changes

### Routing & navigation
- **`src/App.jsx`** — adds `<Route path="/learning" element={<Learning hskLevel={hskLevel}/>}/>` 
- **`src/components/Home.jsx`** — adds a third "Learn" card (book icon, links to `/learning`) below the existing Progress and Practice cards

### Service layer
- **`src/services/ai/aiService.js`** — adds `getWordCards(words, hskLevel)`: `POST /daily-dragon/learning/word-cards`, same fetch pattern as existing functions; omits `hsk_level` from body when null

### New components — `src/components/learning/`
- **`Learning.jsx`** — state machine (`LOADING` → `STUDYING` | `ERROR`). Fetches due words via existing `getDueVocabulary()` then fetches word cards. Never calls `submitReviews`. Shows spinner while loading, error + retry on failure.
- **`LearningCarousel.jsx`** — renders one `WordCard` at a time. Navigation bar: "Back" (home) always on left, card counter centred with prev/next arrows, "Practice these words now" replaces next arrow on the last card.
- **`WordCard.jsx`** — stateless display: large character, pinyin in purple, numbered meanings, numbered example sentences with Chinese line and grey English translation below.

### Tests
- **`src/tests/components/learning/WordCard.test.jsx`** — 5 tests: word, pinyin, meanings, examples, section headers
- **`src/tests/components/learning/LearningCarousel.test.jsx`** — 7 tests: first card on mount, Back button visible, next navigation, prev navigation, prev absent on card 1, Practice button on last card, counter updates
- **`src/tests/services/ai/getWordCards.test.js`** — 5 tests: correct URL/method/body, hsk_level included, hsk_level omitted, throws on error, Authorization header

## SRS invariant
`Learning.jsx` never imports or calls `submitReviews`. Vocabulary scores are completely unaffected by browsing word cards.

## Testing
```bash
npm test
```

## Screenshots
_Home page — new Learn card below Practice:_
> Progress | Practice
> Learn

_Word card:_
> `[character large]`
> `[pinyin]`
> **Meaning** 1. definition
> **Examples** 1. Chinese sentence / English translation

_Navigation bar:_
> [Back]   [←] 3 / 5 [→]   [spacer]
> [Back]   [←] 5 / 5        [Practice these words now]